### PR TITLE
Fix Puppet code styling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To make a node a bootstrap controller, add the following code to the manifest:
 class {'kubernetes':
   controller           => true,
   bootstrap_controller => true,
-  }
+}
 ```
 
 #### Controller
@@ -96,7 +96,7 @@ To make a node a controller, add the following code to the manifest:
 
 class {'kubernetes':
   controller => true,
-  }
+}
 ```
 
 #### Worker


### PR DESCRIPTION
This commit conforms the Puppet code examples in the README to Puppet
styling best practices.