### PR TITLE
Remove hard-coded address from proxy configmap template

### DIFF
--- a/templates/addons/kube-proxy.yaml.erb
+++ b/templates/addons/kube-proxy.yaml.erb
@@ -12,7 +12,7 @@ data:
     clusters:
     - cluster:
         certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        server: https://172.17.10.101:6443
+        server: https://<%= @bootstrap_controller_ip %>:6443
       name: default
     contexts:
     - context:


### PR DESCRIPTION
correct kube-proxy template to use bootstrap_controller_ip rather than a hard-coded address