### PR TITLE
0.1.4 optional cni

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The included configuration tool `kube_tools` auto generates all the security par
 puppet module install puppetlabs-kubernetes --version 0.1.3
 ```
 
-2. Install cfssl. See Cloudflare's [cfssl documentation](https://github.com/cloudflare/cfssl). 
+2. Install cfssl. See Cloudflare's [cfssl documentation](https://github.com/cloudflare/cfssl).
 
 3. Change directory into the root of the module, and run the `bundle install` command.
 
@@ -420,6 +420,8 @@ Defaults to `undef`.
 The network deployment URL that kubectl can locate.
 
 We support networking providers that supports cni.
+
+If set to 'none' no cni plugin is installed.
 
 This defaults to `https://git.io/weave-kube-1.6`.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,20 +1,20 @@
 # Class: kubernetes
 # ===========================
 #
-# A module to build a Kubernetes cluster https://kubernetes.io/ 
+# A module to build a Kubernetes cluster https://kubernetes.io/
 #
 # Parameters
 # ----------
 # [*kubernetes_version*]
 #   The version of Kubernetes containers you want to install.
-#   ie api server, 
+#   ie api server,
 #   Defaults to  1.7.3
 #
 # [*kubernetes_package_version*]
-#   The version of the packages the Kubernetes os packages to install 
+#   The version of the packages the Kubernetes os packages to install
 #   ie kubectl and kubelet
 #   Defaults to 1.7.3
-# 
+#
 # [*cni_version*]
 #   The version of the cni package you would like to install
 #   Defaults to 0.5.1
@@ -45,14 +45,14 @@
 #   Defaults to false
 #
 # [*kube_api_advertise_address*]
-#   This is the ip address that the want to api server to expose. 
+#   This is the ip address that the want to api server to expose.
 #   An example with hiera would be kubernetes::kube_api_advertise_address: "%{::ipaddress_enp0s8}"
-#   defaults to undef 
+#   defaults to undef
 #
 # [*etcd_version*]
 #   The version of etcd that you would like to use.
 #   Defaults to 3.0.17
-# 
+#
 # [*etcd_ip*]
 #   The ip address that you want etcd to use for communications.
 #   An example with hiera would be kubernetes::etcd_ip: "%{::ipaddress_enp0s8}"
@@ -75,7 +75,7 @@
 #
 # [*bootstrap_token_description*]
 #   The boot strap token description, this must be base64 encoded.
-#   An example with hiera would be kubernetes::bootstrap_token_description: VGhlIGRlZmF1bHQgYm9vdHN0cmFwIHRva2VuIHBhc3NlZCB0byB0aGUgY2x1c3RlciB2aWEgUHVwcGV0Lg== # lint:ignore:140chars 
+#   An example with hiera would be kubernetes::bootstrap_token_description: VGhlIGRlZmF1bHQgYm9vdHN0cmFwIHRva2VuIHBhc3NlZCB0byB0aGUgY2x1c3RlciB2aWEgUHVwcGV0Lg== # lint:ignore:140chars
 #
 # [*bootstrap_token_id*]
 #   This is the id the cluster will use to point to the token, this must be base64 encoded.
@@ -91,7 +91,7 @@
 #   This is the bool to use the boot strap token, this must be base64 encoded. (true = dHJ1ZQ==)
 #   An example with hiera would be kubernetes::bootstrap_token_usage_bootstrap_authentication: dHJ1ZQ==
 #   Defaults to undef
-#   
+#
 # [*bootstrap_token_usage_bootstrap_signing*]
 #   This is a bool to use boot trap signing, , this must be base64 encoded. (true = dHJ1ZQ==)
 #   An example with hiera would be kubernetes::bootstrap_token_usage_bootstrap_signing: dHJ1ZQ==
@@ -100,7 +100,7 @@
 # [*certificate_authority_data*]
 #   This is the ca certificate data for the cluster. This must be passed as string not as a file.
 #   Defaults to undef
-# 
+#
 # [*client_certificate_data_controller*]
 #   This is the client certificate data for the controllers. This must be passed as string not as a file.
 #   Defaults to undef
@@ -174,7 +174,7 @@
 #   Defaults to undef
 #
 # [*sa_key*]
-#   The service account key. Must be passed as cert not a file.   
+#   The service account key. Must be passed as cert not a file.
 #   Defaults to undef
 #
 # [*sa_pub*]
@@ -183,7 +183,8 @@
 #
 # [*cni_network_provider*]
 #   This is the url that kubectl can find the networking deployment.
-#   We will support any networking provider that supports cni
+#   We will support any networking provider that supports cni.
+#   If set to 'none' no cni plugin is installed.
 #   This defaults to https://git.io/weave-kube-1.6
 #
 # [*install_dashboard*]
@@ -194,7 +195,7 @@
 # Authors
 # -------
 #
-# Puppet cloud and containers team 
+# Puppet cloud and containers team
 #
 #
 #

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -31,7 +31,7 @@ class kubernetes::kube_addons (
     cwd         => $addon_dir,
     subscribe   => File['/etc/kubernetes/addons/kube-proxy-sa.yaml'],
     refreshonly => true,
-    require     => Exec['Install cni network provider'],
+    onlyif  => 'kubectl get nodes',
   }
 
   exec { 'Create kube proxy ConfigMap':

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -31,7 +31,7 @@ class kubernetes::kube_addons (
     cwd         => $addon_dir,
     subscribe   => File['/etc/kubernetes/addons/kube-proxy-sa.yaml'],
     refreshonly => true,
-    onlyif  => 'kubectl get nodes',
+    onlyif      => 'kubectl get nodes',
   }
 
   exec { 'Create kube proxy ConfigMap':

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -19,10 +19,12 @@ class kubernetes::kube_addons (
     try_sleep   => 5,
     }
 
-  exec { 'Install cni network provider':
-    command => "kubectl apply -f ${cni_network_provider}",
-    onlyif  => 'kubectl get nodes',
+  if $cni_network_provider !== 'none' {
+    exec { 'Install cni network provider':
+      command => "kubectl apply -f ${cni_network_provider}",
+      onlyif  => 'kubectl get nodes',
     }
+  }
 
   exec { 'Create kube proxy service account':
     command     => 'kubectl create -f kube-proxy-sa.yaml',

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -19,7 +19,7 @@ class kubernetes::kube_addons (
     try_sleep   => 5,
     }
 
-  if $cni_network_provider !== 'none' {
+  if $cni_network_provider != 'none' {
     exec { 'Install cni network provider':
       command => "kubectl apply -f ${cni_network_provider}",
       onlyif  => 'kubectl get nodes',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,7 @@ class kubernetes::service (
   $controller = $kubernetes::controller,
   $bootstrap_controller = $kubernetes::bootstrap_controller,
   $etcd_ip = $kubernetes::etcd_ip,
+  $cni_network_provider = $kubernetes::cni_network_provider,
 ){
 
   $peeruls = inline_template("'{\"peerURLs\":[\"http://${etcd_ip}:2380\"]}'")

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -18,7 +18,7 @@ describe 'kubernetes::kube_addons', :type => :class do
       'bootstrap_controller' => true,
       'cni_network_provider' => 'https://foo.test',
       'install_dashboard' => false,
-      'kubernetes_version' => '1.7.3' 
+      'kubernetes_version' => '1.7.3'
       }
     end
 
@@ -41,5 +41,17 @@ describe 'kubernetes::kube_addons', :type => :class do
     end
 
     it { should contain_exec('Install Kubernetes dashboard')}
+  end
+
+  context 'with cni_network_provider => none' do
+    let(:params) do {
+      'bootstrap_controller' => true,
+      'cni_network_provider' => 'none',
+      'install_dashboard' => false,
+      'kubernetes_version' => '1.7.3'
+      }
+    end
+
+    it { should_not contain_exec('Install cni network provider') }
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -18,12 +18,13 @@ describe 'kubernetes::service', :type => :class do
         'controller' => false,
         'bootstrap_controller' => false,
         'etcd_ip' => '127.0.0.1',
+        'cni_network_provider' => 'https://foo.test',
       }
     end
 
    it { should contain_service('docker') }
    it { should contain_file('/etc/systemd/system/kubelet.service.d') }
-   it { should contain_file('/etc/systemd/system/kubelet.service.d/kubernetes.conf') }
+   it { should contain_file('/etc/systemd/system/kubelet.service.d/kubernetes.conf').with_content(/Environment="KUBELET_NETWORK_ARGS/) }
    it { should contain_exec('Reload systemd') }
    it { should contain_service('kubelet') }
   end
@@ -34,9 +35,23 @@ describe 'kubernetes::service', :type => :class do
         'bootstrap_controller' => true,
         'controller' => true,
         'etcd_ip' => '127.0.0.1',
+        'cni_network_provider' => 'https://foo.test',
       }
     end
 
     it { should contain_exec('Checking for the Kubernets cluster to be ready')}
+  end
+
+  context 'with cni_network_provider => none' do
+    let(:params) do
+      {
+        'controller' => false,
+        'bootstrap_controller' => false,
+        'etcd_ip' => '127.0.0.1',
+        'cni_network_provider' => 'none',
+      }
+    end
+
+   it { should contain_file('/etc/systemd/system/kubelet.service.d/kubernetes.conf').without_content(/Environment="KUBELET_NETWORK_ARGS/) }
   end
 end

--- a/templates/kubernetes.conf.erb
+++ b/templates/kubernetes.conf.erb
@@ -1,7 +1,7 @@
 [Service]
 Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true"
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
-<% if @cni_network_provider !== 'none' -%>Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"<% end %> 
+<% if @cni_network_provider != 'none' -%>Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"<% end %> 
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
 Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
 ExecStart=

--- a/templates/kubernetes.conf.erb
+++ b/templates/kubernetes.conf.erb
@@ -1,7 +1,7 @@
 [Service]
 Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true"
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
-Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
+<% if @cni_network_provider !== 'none' -%>Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"<% end %> 
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
 Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
 ExecStart=


### PR DESCRIPTION
adds the possibility to explicitly have no cni network provider (e.g. when manual l3 routing between nodes is used)
I don't know if a version bump (to 0.1.5) is necessary since the change does not change the default behavior.