### PR TITLE
(CLOUD-1640) Remove package resource for kubernetes-cni

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -37,10 +37,6 @@ class kubernetes::packages (
 
     default: { notify {"The OS family ${::os_family} is not supported by this module":} }
     }
-
-    package { 'kubernetes-cni':
-      ensure => $cni_version,
-    }
   }
 
   elsif $container_runtime == 'cri_containerd' {

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -14,6 +14,5 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('docker-engine').with_ensure('1.12.0-0~xenial')}
     it { should contain_package('kubelet').with_ensure('1.7.3-01')}
     it { should contain_package('kubectl').with_ensure('1.7.3-01')}
-    it { should contain_package('kubernetes-cni').with_ensure('0.5.1-00')}
   end
 end


### PR DESCRIPTION
Prior to this commit, kubernetes-cni was installed as a separate
package resource.  Regardless of the version specified, yum would
detect the kubelet prerequisite, which would automatically pull the
latest version.  Since we install kubelet just a few lines later,
and that installation will automatically pull the needed version
of kubernetes-cni, this package resource appears to not be needed,
and causes the incorrect version to get installed.

Removing it resolved the errors since the needed dependencies will be
pulled in when kubelet is installed.

would automatically pull in the most recent version