### PR TITLE
(CLOUD-1701) Add path attribute to execs in kube_addons

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -9,10 +9,6 @@ class kubernetes::kube_addons (
   Boolean $taint_master                  = $kubernetes::taint_master,
 ){
 
-  if $bootstrap_controller {
-
-  $addon_dir = '/etc/kubernetes/addons'
-
   Exec {
     path        => ['/usr/bin', '/bin'],
     environment => [ 'HOME=/root', 'KUBECONFIG=/root/admin.conf'],
@@ -20,6 +16,10 @@ class kubernetes::kube_addons (
     tries       => 5,
     try_sleep   => 5,
     }
+
+  if $bootstrap_controller {
+
+  $addon_dir = '/etc/kubernetes/addons'
 
   exec { 'Install cni network provider':
     command => "kubectl apply -f ${cni_network_provider}",


### PR DESCRIPTION
Prior to this commit, puppet agent runs on a controller would
fail because there is a relative path used in the assign master role
and taint master node execs.  These paths are present in the
resource default, but that is contained within the bootstrap-controller
conditional and thus not available for controllers.  This patch moves
the resource default above the conditional so it is present for both.
