### PR TITLE
Bugfix/docker apt repo gpg key fix

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -24,8 +24,8 @@ class kubernetes::repos (
             repos    => 'main',
             release  => 'ubuntu-xenial',
             key      => {
-              'id'     => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
-              'source' => 'https://download.docker.com/linux/ubuntu/gpg',
+              'id'     => '58118E89F3A912897C070ADBF76221572C52609D',
+              'source' => 'https://apt.dockerproject.org/gpg',
           },
         }
       }

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -17,7 +17,13 @@ describe 'kubernetes::repos', :type => :class do
     let(:params) { { 'container_runtime' => 'docker' } }
 
     it { should contain_apt__source('kubernetes') }
-    it { should contain_apt__source('docker') }
+    it { should contain_apt__source('docker').with(
+              :ensure   => 'present',
+              :location => 'https://apt.dockerproject.org/repo',
+              :repos    => 'main',
+              :release  => 'ubuntu-xenial',
+              :key      => { 'id' => '58118E89F3A912897C070ADBF76221572C52609D', 'source' => 'https://apt.dockerproject.org/gpg' }
+       ) }
 
   end
 


### PR DESCRIPTION
Apt repo at https://apt.dockerproject.org/repo/ using gpg key https://apt.dockerproject.org/gpg with fingerprint `58118E89F3A912897C070ADBF76221572C52609D`.
Repo at https://download.docker.com/linux/ubuntu/ using gpg key https://download.docker.com/linux/ubuntu/gpg with fingerprint `9DC858229FC7DD38854AE2D88D81803C0EBFCD88`.