### PR TITLE
changing taint and label to fqdn

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -76,8 +76,8 @@ class kubernetes::kube_addons (
 
   if $controller {
     exec { 'Assign master role to controller':
-      command => "kubectl label node ${::hostname} node-role.kubernetes.io/master=",
-      unless  => "kubectl describe nodes ${::hostname} | tr -s ' ' | grep 'Roles: master'",
+      command => "kubectl label node ${::fqdn} node-role.kubernetes.io/master=",
+      unless  => "kubectl describe nodes ${::fqdn} | tr -s ' ' | grep 'Roles: master'",
     }
 
     if $taint_master {
@@ -92,9 +92,9 @@ class kubernetes::kube_addons (
         }
 
       exec { 'Taint master node':
-        command => "kubectl taint nodes ${::hostname} key=value:NoSchedule",
+        command => "kubectl taint nodes ${::fqdn} key=value:NoSchedule",
         onlyif  => 'kubectl get nodes',
-        unless  => "kubectl describe nodes ${::hostname} | tr -s ' ' | grep 'Taints: key=value:NoSchedule'"
+        unless  => "kubectl describe nodes ${::fqdn} | tr -s ' ' | grep 'Taints: key=value:NoSchedule'"
       }
     }
   }


### PR DESCRIPTION
fixes #60 

Where a node has a FQDN, this will allow the role/taint to be applied correctly. Where the shortname and FQDN are the same, this will also work without issue. 