### PR TITLE
Allow mounting extra volumes to apiserver pod

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,6 +44,7 @@ class kubernetes::config (
   Optional[String] $apiserver_crt                                  = $kubernetes::apiserver_crt,
   Optional[String] $apiserver_key                                  = $kubernetes::apiserver_key,
   Array $apiserver_extra_arguments                                 = $kubernetes::apiserver_extra_arguments,
+  Array $apiserver_extra_volumes                                   = $kubernetes::apiserver_extra_volumes,
   Optional[String] $ca_crt                                         = $kubernetes::ca_crt,
   Optional[String] $ca_key                                         = $kubernetes::ca_key,
   Optional[String] $front_proxy_ca_crt                             = $kubernetes::front_proxy_ca_crt,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,10 +59,6 @@
 #   An example with hiera would be kubernetes::kube_api_advertise_address: "%{::ipaddress_enp0s8}"
 #   defaults to undef
 #
-# [*$apiserver_extra_arguments*]
-#   This is an array to pass extra configuration to the Kubernetes api.
-#   Defaults to []
-#
 # [*etcd_version*]
 #   The version of etcd that you would like to use.
 #   Defaults to 3.0.17
@@ -167,6 +163,11 @@
 #
 # [*apiserver_extra_arguments*]
 #   A string array of extra arguments to be passed to the api server.
+#   Defaults to []
+#
+# [*apiserver_extra_volumes*]
+#   An array of objects describing additional volumes and volumeMounts to be configured in the api server pod. Each
+#   value should be a hash with `name`, `hostPath`, `mountPath`, and `readOnly` properties.
 #   Defaults to []
 #
 # [*ca_crt*]
@@ -281,6 +282,7 @@ class kubernetes (
   Optional[String] $apiserver_crt                                  = $kubernetes::params::apiserver_crt,
   Optional[String] $apiserver_key                                  = $kubernetes::params::apiserver_key,
   Array $apiserver_extra_arguments                                 = $kubernetes::params::apiserver_extra_arguments,
+  Array $apiserver_extra_volumes                                   = $kubernetes::params::apiserver_extra_volumes,
   Optional[String] $ca_crt                                         = $kubernetes::params::ca_crt,
   Optional[String] $ca_key                                         = $kubernetes::params::ca_key,
   Optional[String] $front_proxy_ca_crt                             = $kubernetes::params::front_proxy_ca_crt,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,7 @@ $apiserver_kubelet_client_key = undef
 $apiserver_crt = undef
 $apiserver_key = undef
 $apiserver_extra_arguments = []
+$apiserver_extra_volumes = []
 $ca_crt = undef
 $ca_key = undef
 $front_proxy_ca_crt = undef

--- a/spec/classes/cluster_roles_spec.rb
+++ b/spec/classes/cluster_roles_spec.rb
@@ -42,6 +42,7 @@ describe 'kubernetes::cluster_roles', :type => :class do
         apiserver_crt => "foo",
         apiserver_key => "foo",
         apiserver_extra_arguments => ["--some-extra-arg=foo"],
+        apiserver_extra_volumes => [],
         kubernetes_fqdn => "kube.foo.dev",
         ca_crt => "foo",
         ca_key => "foo",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -57,6 +57,12 @@ describe 'kubernetes::config', :type => :class do
         'apiserver_crt' => 'foo',
         'apiserver_key' => 'foo',
         'apiserver_extra_arguments' => ['--some-extra-arg=foo'],
+        'apiserver_extra_volumes' => [{
+            'name' => 'customvolume',
+            'hostPath' => '/path/on/host',
+            'mountPath' => '/path/in/container',
+            'readOnly' => true,
+        }],
         'kubernetes_fqdn' => 'kube.foo.dev',
         'ca_crt' => 'foo',
         'ca_key' => 'foo',
@@ -109,6 +115,8 @@ describe 'kubernetes::config', :type => :class do
         should contain_file('/etc/kubernetes/manifests/kube-apiserver.yaml')
                    .with_content(/^\s*- --experimental-bootstrap-token-auth=true$/) # with kubernetes_version = 1.7.x
                    .with_content(/^\s*- --some-extra-arg=foo$/)
+                   .with_content(/^\s*- mountPath: \/path\/in\/container\n\s*name: customvolume\n\s*readOnly: true$/)
+                   .with_content(/^\s*- hostPath:\n\s*path: \/path\/on\/host\n\s*name: customvolume$/)
       }
     end
 
@@ -156,6 +164,12 @@ describe 'kubernetes::config', :type => :class do
       'apiserver_crt' => 'foo',
       'apiserver_key' => 'foo',
       'apiserver_extra_arguments' => ['--some-extra-arg=foo'],
+      'apiserver_extra_volumes' => [{
+          'name' => 'customvolume',
+          'hostPath' => '/path/on/host',
+          'mountPath' => '/path/in/container',
+          'readOnly' => true,
+      }],
       'kubernetes_fqdn' => 'kube.foo.dev',
       'ca_crt' => 'foo',
       'ca_key' => 'foo',

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -54,6 +54,7 @@ describe 'kubernetes::kube_addons', :type => :class do
     apiserver_crt => "foo",
     apiserver_key => "foo",
     apiserver_extra_arguments => ["--some-extra-arg=foo"],
+    apiserver_extra_volumes => [],
     kubernetes_fqdn => "kube.foo.dev",
     ca_crt => "foo",
     ca_key => "foo",

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -44,6 +44,7 @@ describe 'kubernetes::packages', :type => :class do
     apiserver_crt => "foo",
     apiserver_key => "foo",
     apiserver_extra_arguments => ["--some-extra-arg=foo"],
+    apiserver_extra_volumes => [],
     kubernetes_fqdn => "kube.foo.dev",
     ca_crt => "foo",
     ca_key => "foo",

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -54,6 +54,7 @@ describe 'kubernetes::service', :type => :class do
     apiserver_crt => "foo",
     apiserver_key => "foo",
     apiserver_extra_arguments => ["--some-extra-arg=foo"],
+    apiserver_extra_volumes => [],
     kubernetes_fqdn => "kube.foo.dev",
     ca_crt => "foo",
     ca_key => "foo",

--- a/templates/kube-apiserver.yaml.erb
+++ b/templates/kube-apiserver.yaml.erb
@@ -68,6 +68,13 @@ spec:
       readOnly: true
     - mountPath: /etc/ssl/certs
       name: certs
+<% @apiserver_extra_volumes.each do |vol| -%>
+    - mountPath: <%= vol['mountPath'] %>
+      name: <%= vol['name'] %>
+      <%- if vol['readOnly'] -%>
+      readOnly: true
+      <%- end -%>
+<% end -%>
   hostNetwork: true
   volumes:
   - hostPath:
@@ -76,4 +83,9 @@ spec:
   - hostPath:
       path: /etc/ssl/certs
     name: certs
+<% @apiserver_extra_volumes.each do |vol| -%>
+  - hostPath:
+      path: <%= vol['hostPath'] %>
+    name: <%= vol['name'] %>
+<% end -%>
 status: {}


### PR DESCRIPTION
In some environments, additional volumes are rqeuired for the apiserver
to function as expected. For example, on CentOS 7 controller nodes, the
host CA certificate bundles mounted at /etc/ssl/certs are broken since
this directory contains symlinks pointing to an unmounted path.

In other environments this may be used to provision a specific directory
which is referred to by other apiserver arugments, e.g.
"--oidc-ca-file".