### PR TITLE
Allow custom docker_repo_name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,18 @@ Allows the user to override the label of a node.
 
 Defaults to `hostname`.
 
+#### `docker_repo_name`
+
+Name for the docker repo.
+
+Defaults to `docker`.
+
+#### `docker_package_name`
+
+Name for the docker package.
+
+Defaults to `docker-engine`.
+
 #### `docker_version`
 
 Specifies the version of the docker runtime you want to install.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,11 +18,19 @@
 # [*container_runtime*]
 #   This is the runtime that the Kubernetes cluster will use.
 #   It can only be set to "cri_containerd" or "docker"
-#   Defaults to cri_containerd
+#   Defaults to `docker`.
 #
 # [*containerd_version*]
 #   This is the version of the containerd runtime the module will install.
 #   Defaults to 1.1.0
+#
+# [*docker_repo_name*]
+#   The name of the docker repo.
+#   Defaults to `docker`.
+#
+# [*docker_package_name*]
+#   The name of the docker package you would like to install.
+#   Defaults to `docker-engine`.
 #
 # [*docker_version*]
 #   This is the version of the docker runtime that you want to install.
@@ -176,6 +184,8 @@ class kubernetes (
   Optional[String] $containerd_version                             = $kubernetes::params::containerd_version,
   Optional[String] $docker_version                                 = $kubernetes::params::docker_version,
   Optional[String] $cni_pod_cidr                                   = $kubernetes::params::cni_pod_cidr,
+  Optional[String] $docker_repo_name                               = $kubernetes::params::docker_repo_name,
+  Optional[String] $docker_package_name                            = $kubernetes::params::docker_package_name,
   Boolean $controller                                              = $kubernetes::params::controller,
   Boolean $worker                                                  = $kubernetes::params::worker,
   Optional[String] $kube_api_advertise_address                     = $kubernetes::params::kube_api_advertise_address,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,8 @@ case $::osfamily {
 $container_runtime = 'docker'
 $containerd_version = '1.1.0'
 $etcd_version = '3.1.12'
+$docker_repo_name = 'docker'
+$docker_package_name = 'docker-engine'
 $kubernetes_fqdn = 'kubernetes'
 $controller = false
 $bootstrap_controller = false

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -2,6 +2,7 @@
 
 class kubernetes::repos (
   String $container_runtime = $kubernetes::container_runtime,
+  String $docker_repo_name  = $kubernetes::docker_repo_name,
 ){
 
   case $::osfamily  {
@@ -17,7 +18,7 @@ class kubernetes::repos (
         }
 
         if $container_runtime == 'docker' {
-          apt::source { 'docker':
+          apt::source { $docker_repo_name :
             location => 'https://apt.dockerproject.org/repo',
             repos    => 'main',
             release  => 'ubuntu-xenial',
@@ -30,7 +31,7 @@ class kubernetes::repos (
     }
     'RedHat': {
       if $container_runtime == 'docker' {
-        yumrepo { 'docker':
+        yumrepo { $docker_repo_name :
           descr    => 'docker',
           baseurl  => 'https://yum.dockerproject.org/repo/main/centos/7',
           gpgkey   => 'https://yum.dockerproject.org/gpg',

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -3,6 +3,11 @@ describe 'kubernetes::repos', :type => :class do
 
   
   context 'with osfamily => Ubuntu' do
+    let(:pre_condition) { 'class {"kubernetes":
+      docker_repo_name => "docker",
+      kube_dns_ip => "10.96.0.10",
+      kube_api_service_ip => "10.96.0.1" }
+    '}
     let(:facts) do
       {
         :operatingsystem => 'Ubuntu',
@@ -36,7 +41,57 @@ describe 'kubernetes::repos', :type => :class do
 
   end
 
+  context 'with osfamily => Ubuntu and docker_repo_name => docker_kubernetes' do
+    let(:pre_condition) { 'class {"kubernetes":
+      docker_repo_name => "docker",
+      kube_dns_ip => "10.96.0.10",
+      kube_api_service_ip => "10.96.0.1" }
+    '}
+    let(:facts) do
+      {
+        :operatingsystem => 'Ubuntu',
+        :osfamily => 'Debian',
+        :os               => {
+          :name    => 'Ubuntu',
+          :release => {
+            :full => '16.04',
+          },
+        },
+      }
+    end
+
+    let(:params) do 
+      { 
+        'container_runtime' => 'docker',
+        'docker_repo_name'  => 'docker_kubernetes',
+      
+      }
+    end
+
+    it { should contain_apt__source('kubernetes').with(
+      :ensure   => 'present',
+      :location => 'http://apt.kubernetes.io',
+      :repos    => 'main',
+      :release  => 'kubernetes-xenial',
+      :key      => { 'id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB', 'source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' }
+    ) }
+
+    it { should contain_apt__source('docker_kubernetes').with(
+      :ensure   => 'present',
+      :location => 'https://apt.dockerproject.org/repo',
+      :repos    => 'main',
+      :release  => 'ubuntu-xenial',
+      :key      => { 'id' => '58118E89F3A912897C070ADBF76221572C52609D', 'source' => 'https://apt.dockerproject.org/gpg' }
+    ) }
+
+  end
+
   context 'with osfamily => RedHat and manage_epel => true' do
+    let(:pre_condition) { 'class {"kubernetes":
+      docker_repo_name => "docker",
+      kube_dns_ip => "10.96.0.10",
+      kube_api_service_ip => "10.96.0.1" }
+    '}
     let(:facts) do
       {
         :operatingsystem => 'RedHat',
@@ -48,6 +103,32 @@ describe 'kubernetes::repos', :type => :class do
     let(:params) { { 'container_runtime' => 'docker' } }
 
     it { should contain_yumrepo('docker') }
+    it { should contain_yumrepo('kubernetes') }
+  end
+
+  context 'with osfamily => RedHat and docker_repo_name => docker_kubernetes' do
+    let(:pre_condition) { 'class {"kubernetes":
+      docker_repo_name => "docker",
+      kube_dns_ip => "10.96.0.10",
+      kube_api_service_ip => "10.96.0.1" }
+    '}
+    let(:facts) do
+      {
+        :operatingsystem => 'RedHat',
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '7.0',
+      }
+    end
+
+    let(:params) do 
+      { 
+        'container_runtime' => 'docker',
+        'docker_repo_name'  => 'docker_kubernetes',
+      
+      }
+    end
+
+    it { should contain_yumrepo('docker_kubernetes') }
     it { should contain_yumrepo('kubernetes') }
   end
 end


### PR DESCRIPTION
We have a repo called 'docker' already in use internally for standalone Docker nodes, which conflicts with the Kubernetes module's repo name.