### PR TITLE
Fix for failing idempotency on worker nodes

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -22,7 +22,9 @@ class kubernetes::cluster_roles (
 
 ){
   $path = ['/usr/bin','/bin','/sbin','/usr/local/bin']
-  $env = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf']
+  $env_controller = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf']
+  #Worker nodes do not have admin.conf present
+  $env_worker = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf']
 
   if $container_runtime == 'cri_containerd' {
     $preflight_errors = ['Service-Docker']
@@ -37,7 +39,7 @@ class kubernetes::cluster_roles (
     kubernetes::kubeadm_init { $node_label:
       config                  => '/etc/kubernetes/config.yaml',
       path                    => $path,
-      env                     => $env,
+      env                     => $env_controller,
       node_label              => $node_label,
       ignore_preflight_errors => $preflight_errors,
       }
@@ -46,7 +48,7 @@ class kubernetes::cluster_roles (
   if $worker {
     kubernetes::kubeadm_join { $node_label:
       path                    => $path,
-      env                     => $env,
+      env                     => $env_worker,
       controller_address      => $controller_address,
       token                   => $token,
       ca_cert_hash            => $discovery_token_hash,


### PR DESCRIPTION
Fix for failing idempotency on worker nodes, since these do not have the admin.conf:

```
Debug: Exec[kubeadm join](provider=posix): Executing check 'kubectl get nodes | grep ics106067240'
Debug: Executing: 'kubectl get nodes | grep ics106067240'
Debug: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/unless: The connection to the server localhost:8080 was refused - did you specify the right host or port?
Debug: Exec[kubeadm join](provider=posix): Executing 'kubeadm join '146.106.67.212:6443' --discovery-token-ca-cert-hash 'sha256:xxx' --token 'xxx''
Debug: Executing: 'kubeadm join '146.106.67.212:6443' --discovery-token-ca-cert-hash 'sha256:xxx' --token 'xxx''
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns: [preflight] Running pre-flight checks.
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns:         [WARNING Service-Kubelet]: kubelet service is not enabled, please run 'systemctl enable kubelet.service'
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns:         [WARNING FileExisting-crictl]: crictl not found in system path
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns: Suggestion: go get github.com/kubernetes-incubator/cri-tools/cmd/crictl
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns: [preflight] Some fatal errors occurred:
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns:         [ERROR Port-10250]: Port 10250 is in use
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns:         [ERROR FileAvailable--etc-kubernetes-pki-ca.crt]: /etc/kubernetes/pki/ca.crt already exists
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns:         [ERROR FileAvailable--etc-kubernetes-kubelet.conf]: /etc/kubernetes/kubelet.conf already exists
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns:         [ERROR FileAvailable--etc-kubernetes-bootstrap-kubelet.conf]: /etc/kubernetes/bootstrap-kubelet.conf already exists
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns: [preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
Error: 'kubeadm join '146.106.67.212:6443' --discovery-token-ca-cert-hash 'sha256:xxx' --token 'xxx'' returned 2 instead of one of [0]
Error: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[ics106067240]/Exec[kubeadm join]/returns: change from 'notrun' to ['0'] failed: 'kubeadm join '146.106.67.212:6443' --discovery-token-ca-cert-hash 'sha256:xxx' --token 'xxx'' returned 2 instead of one of [0]
```

Second run fails, because the exec resource has an unless which checks for nodes, which in turn fails because of the missing config file. This triggers an error, since the exec resource will attempt to join the node to the cluster for the second time.