### PR TITLE
Allow arbitrary extra kubeadm config.yaml snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ The name of the cloud provider configured in `/etc/kubernetes/cloud-config`.
 
 Defaults to `undef`.
 
+#### `kubeadm_extra_config`
+
+A hash containing extra configuration data to be serialised with `to_yaml` and appended to the config.yaml file used by kubeadm.
+
+Defaults to `{}`.
+
 #### `kubernetes_apt_location`
 The APT repo URL for the Kubernetes packages.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,7 +29,7 @@ class kubernetes::config (
   String $service_cidr = $kubernetes::service_cidr,
   String $node_label = $kubernetes::node_label,
   Optional[String] $cloud_provider = $kubernetes::cloud_provider,
-
+  Hash $kubeadm_extra_config = $kubernetes::kubeadm_extra_config,
 ) {
 
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']
@@ -62,6 +62,9 @@ class kubernetes::config (
     ensure  => present,
     content => template('kubernetes/etcd/etcd.service.erb'),
   }
+
+  # to_yaml emits a complete YAML document, so we must remove the leading '---'
+  $kubeadm_extra_config_yaml = regsubst(to_yaml($kubeadm_extra_config), '^---\n', '')
 
   file { '/etc/kubernetes/config.yaml':
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,6 +194,10 @@
 #  Note: this file is not managed within this module and must be present before bootstrapping the kubernetes controller
 #  Defaults to undef
 #
+# [*kubeadm_extra_config*]
+#  A hash containing extra configuration data to be serialised with `to_yaml` and appended to the config.yaml file used by kubeadm.
+#  Defaults to {}
+#
 # [*kubernetes_apt_location*]
 #  The APT repo URL for the Kubernetes packages.
 #  Defaults to https://apt.kubernetes.io
@@ -305,6 +309,7 @@ class kubernetes (
   String $node_label                                               = $kubernetes::params::node_label,
   Optional[String] $controller_address                             = $kubernetes::params::controller_address,
   Optional[String] $cloud_provider                                 = $kubernetes::params::cloud_provider,
+  Hash $kubeadm_extra_config                                       = $kubernetes::params::kubeadm_extra_config,
   Optional[String] $runc_source                                    = $kubernetes::params::runc_source,
   Optional[String] $containerd_archive                             = $kubernetes::params::containerd_archive,
   Optional[String] $containerd_source                              = $kubernetes::params::containerd_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,6 +58,7 @@ $apiserver_extra_arguments = []
 $service_cidr = '10.96.0.0/12'
 $controller_address = undef
 $cloud_provider = undef
+$kubeadm_extra_config = {}
 $kubernetes_apt_location = 'http://apt.kubernetes.io'
 $kubernetes_apt_release = "kubernetes-${::lsbdistcodename}"
 $kubernetes_apt_repos = 'main'

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -31,6 +31,7 @@ describe 'kubernetes::config', :type => :class do
         'service_cidr' => '10.96.0.0/12',
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
+        'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
         }
     end
 
@@ -53,5 +54,6 @@ describe 'kubernetes::config', :type => :class do
 
     it { should contain_file('/etc/systemd/system/etcd.service') }
     it { should contain_file('/etc/kubernetes/config.yaml') }
+    it { should contain_file('/etc/kubernetes/config.yaml').with_content(/foo:\n- bar\n- baz/) }
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -42,8 +42,9 @@ describe 'kubernetes::service', :type => :class do
         apiserver_extra_arguments => ["foo"],
         service_cidr => "10.96.0.0/12",
         node_label => "foo",
-        cloud_provider => ":undef",} 
-    ' }    
+        cloud_provider => ":undef",
+        kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+      }' }
     let(:params) do
       {
         'container_runtime' => 'cri_containerd',
@@ -89,8 +90,9 @@ describe 'kubernetes::service', :type => :class do
         apiserver_extra_arguments => ["foo"],
         service_cidr => "10.96.0.0/12",
         node_label => "foo",
-        cloud_provider => ":undef",}         
-    ' }    
+        cloud_provider => ":undef",
+        kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+      }' }
     let(:params) do
         {
             'container_runtime' => 'docker',

--- a/templates/config.yaml.erb
+++ b/templates/config.yaml.erb
@@ -33,3 +33,4 @@ apiServerCertSANs:
 <%- if @cloud_provider  -%>
 cloudProvider: <%= @cloud_provider %>
 <%- end -%>
+<%= @kubeadm_extra_config_yaml %>


### PR DESCRIPTION
Provide an extension point `kubeadm_extra_config` to allow configuration
of all kubeadm config properties not otherwise explicitly exposed.