### PR TITLE
Fixed indenting issue when configuring multiple extra apiserver cert SANs

### DIFF
--- a/templates/config.yaml.erb
+++ b/templates/config.yaml.erb
@@ -26,7 +26,7 @@ CRISocket: /run/containerd/containerd.sock
 <%- end -%>
 <%- if @apiserver_cert_extra_sans -%>
 apiServerCertSANs:
-  <% @apiserver_cert_extra_sans.each do |san| -%>
+<% @apiserver_cert_extra_sans.each do |san| -%>
 - <%= san %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
There was still an issue when you have a 2nd SAN it is indenting differently from the first SAN.