### PR TITLE
 Add feature flag for managing Docker repositories and packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,10 @@
 #   This is a bool that sets a node to a worker.
 #   defaults to false 
 #
+# [*manage_docker*]
+#   Whether or not to install Docker repositories and packages via this module.
+#   Defaults to true.
+#
 # [*kube_api_advertise_address*]
 #   This is the ip address that the want to api server to expose.
 #   An example with hiera would be kubernetes::kube_api_advertise_address: "%{::ipaddress_enp0s8}"
@@ -279,6 +283,7 @@ class kubernetes (
   Optional[String] $cni_pod_cidr                                   = $kubernetes::params::cni_pod_cidr,
   Boolean $controller                                              = $kubernetes::params::controller,
   Boolean $worker                                                  = $kubernetes::params::worker,
+  Boolean $manage_docker                                           = $kubernetes::params::manage_docker,
   Optional[String] $kube_api_advertise_address                     = $kubernetes::params::kube_api_advertise_address,
   Optional[String] $etcd_version                                   = $kubernetes::params::etcd_version,
   Optional[String] $etcd_ip                                        = $kubernetes::params::etcd_ip,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -4,6 +4,7 @@ class kubernetes::packages (
 
   String $kubernetes_package_version           = $kubernetes::kubernetes_package_version,
   String $container_runtime                    = $kubernetes::container_runtime,
+  Boolean $manage_docker                       = $kubernetes::manage_docker,
   Optional[String] $docker_version             = $kubernetes::docker_version,
   Optional[String] $docker_package_name        = $kubernetes::docker_package_name,
   Boolean $controller                          = $kubernetes::controller,
@@ -43,7 +44,7 @@ class kubernetes::packages (
     }
   }
 
-  if $container_runtime == 'docker' {
+  if $container_runtime == 'docker' and $manage_docker == true {
     case $::osfamily {
       'Debian': {
         package { $docker_package_name:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,7 @@ $kubernetes_fqdn = 'kubernetes'
 $controller = false
 $bootstrap_controller = false
 $worker =  false
+$manage_docker = true
 $kube_api_advertise_address = undef
 $etcd_ip = undef
 $etcd_initial_cluster = undef

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -16,6 +16,7 @@ class kubernetes::repos (
   Optional[String] $docker_yum_gpgkey       = $kubernetes::docker_yum_gpgkey,
   Optional[String] $docker_key_id           = $kubernetes::docker_key_id,
   Optional[String] $docker_key_source       = $kubernetes::docker_key_source,
+  Boolean $manage_docker                    = $kubernetes::manage_docker,
   Boolean $create_repos                     = $kubernetes::create_repos,
 
 
@@ -33,7 +34,7 @@ class kubernetes::repos (
             },
           }
 
-          if $container_runtime == 'docker' {
+          if $container_runtime == 'docker' and $manage_docker == true {
             apt::source { 'docker':
               location => $docker_apt_location,
               repos    => $docker_apt_repos,
@@ -46,7 +47,7 @@ class kubernetes::repos (
         }
       }
       'RedHat': {
-        if $container_runtime == 'docker' {
+        if $container_runtime == 'docker' and $manage_docker == true {
           yumrepo { 'docker':
             descr    => 'docker',
             baseurl  => $docker_yum_baseurl,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,6 +3,7 @@
 class kubernetes::service (
   String $container_runtime         = $kubernetes::container_runtime,
   Boolean $controller               = $kubernetes::controller,
+  Boolean $manage_docker            = $kubernetes::manage_docker,
   Optional[String] $cloud_provider  = $kubernetes::cloud_provider,
 ){
   file { '/etc/systemd/system/kubelet.service.d':
@@ -17,10 +18,14 @@ class kubernetes::service (
 
   case $container_runtime {
     'docker': {
-      service { 'docker':
-        ensure => running,
-        enable => true,
+
+      if $manage_docker == true {
+        service { 'docker':
+          ensure => running,
+          enable => true,
+        }
       }
+
     }
 
     'cri_containerd': {

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'kubernetes::packages', :type => :class do
-  context 'with osfamily => RedHat and container_runtime => Docker' do
+  context 'with osfamily => RedHat and container_runtime => Docker and manage_docker => true' do
     let(:facts) do
         {
           :lsbdistcodename  => 'xenial',
@@ -28,6 +28,7 @@ describe 'kubernetes::packages', :type => :class do
         'controller' => true,
         'docker_package_name' => 'docker-engine',   
         'disable_swap' => true,
+        'manage_docker' => true,
         }
     end
 
@@ -67,6 +68,7 @@ describe 'kubernetes::packages', :type => :class do
         'controller' => true, 
         'docker_package_name' => 'docker-engine',  
         'disable_swap' => true,
+        'manage_docker' => true,
         }
     end
 
@@ -78,6 +80,45 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubectl').with_ensure('1.10.2-00')}
     it { should contain_package('kubeadm').with_ensure('1.10.2-00')}
     
+  end
+  
+  context 'with osfamily => Debian and container_runtime => Docker and manage_docker => false' do
+    let(:facts) do
+        {
+          :lsbdistcodename  => 'xenial',
+          :kernel           => 'Linux',
+          :osfamily         => 'Debian',
+          :operatingsystem  => 'Ubuntu',
+          :os               => {
+            :name    => 'Ubuntu',
+            :release => {
+              :full => '16.04',
+            },
+          },
+        }
+    end
+    let(:params) do
+        {
+        'container_runtime' => 'docker',
+        'kubernetes_package_version' => '1.10.2',
+        'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
+        'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
+        'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
+        'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
+        'runc_source' => 'https://github.com/runcsource',
+        'controller' => true,
+        'docker_package_name' => 'docker-engine',   
+        'disable_swap' => true,
+        'manage_docker' => false,
+        }
+    end
+
+    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should contain_package('kubelet').with_ensure('1.10.2')}
+    it { should contain_package('kubectl').with_ensure('1.10.2')}
+    it { should contain_package('kubeadm').with_ensure('1.10.2')}
+    it { should_not contain_package('docker-engine').with_ensure('17.03.0~ce-0~ubuntu-xenial')}
   end
 
   context 'with disable_swap => true' do
@@ -107,7 +148,7 @@ describe 'kubernetes::packages', :type => :class do
         'controller' => true, 
         'docker_package_name' => 'docker-engine',  
         'disable_swap' => true,
-        
+        'manage_docker' => true, 
         }
     end
 

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 describe 'kubernetes::repos', :type => :class do
 
   
-  context 'with osfamily => Ubuntu' do
+  context 'with osfamily => Ubuntu and manage_docker => true' do
     let(:facts) do
       {
         :lsbdistcodename  => 'xenial',
@@ -35,7 +35,8 @@ describe 'kubernetes::repos', :type => :class do
          'docker_key_id' => '58118E89F3A912897C070ADBF76221572C52609D',
          'docker_key_source' => 'https://apt.dockerproject.org/gpg',
          'create_repos' => true,         
-        }
+         'manage_docker' => true, 
+       }
     end    
 
     it { should contain_apt__source('kubernetes').with(
@@ -56,7 +57,7 @@ describe 'kubernetes::repos', :type => :class do
 
   end
 
-  context 'with osfamily => RedHat and manage_epel => true' do
+  context 'with osfamily => RedHat and manage_epel => true and manage_docker => false' do
     let(:facts) do
       {
         :operatingsystem => 'RedHat',
@@ -82,11 +83,12 @@ describe 'kubernetes::repos', :type => :class do
         'docker_yum_gpgkey' => 'https://yum.dockerproject.org/gpg',
         'docker_key_id' => '58118E89F3A912897C070ADBF76221572C52609D',
         'docker_key_source' => 'https://apt.dockerproject.org/gpg',
-        'create_repos' => true,         
+        'create_repos' => true,
+        'manage_docker' => false,
        }
    end 
 
-    it { should contain_yumrepo('docker') }
+    it { should_not contain_yumrepo('docker') }
     it { should contain_yumrepo('kubernetes') }
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -50,7 +50,7 @@ describe 'kubernetes::service', :type => :class do
         'container_runtime' => 'cri_containerd',
       'controller' => true,
       'cloud_provider' => ':undef',
-      
+      'manage_docker' => true,   
       }
     end
    it { should contain_file('/etc/systemd/system/kubelet.service.d')}
@@ -61,7 +61,7 @@ describe 'kubernetes::service', :type => :class do
    it { should contain_service('etcd')}
   end
 
-  context 'with controller => true and container_runtime => docker' do
+  context 'with controller => true and container_runtime => docker and manage_docker => true' do
     let(:pre_condition) { 'class {"kubernetes::config":
         kubernetes_version => "1.10.2",
         container_runtime => "docker",
@@ -98,9 +98,54 @@ describe 'kubernetes::service', :type => :class do
             'container_runtime' => 'docker',
             'controller' => true,
             'cloud_provider' => ':undef',
+            'manage_docker' => true,
         }
     end
     it { should contain_service('docker')}
+    it { should contain_service('etcd')}
+  end
+  
+  context 'with controller => true and container_runtime => docker and manage_docker => false' do
+    let(:pre_condition) { 'class {"kubernetes::config":
+        kubernetes_version => "1.10.2",
+        container_runtime => "docker",
+        etcd_version => "3.1.12",
+        etcd_ca_key => "foo",
+        etcd_ca_crt => "foo", 
+        etcdclient_key => "foo",
+        etcdclient_crt => "foo",
+        api_server_count => 3,
+        kubernetes_ca_crt => "foo",
+        kubernetes_ca_key => "foo",
+        discovery_token_hash => "foo",
+        sa_pub => "foo",
+        sa_key => "foo",
+        kube_api_advertise_address => "foo",
+        cni_pod_cidr => "10.0.0.0/24",
+        etcdserver_crt => "foo", 
+        etcdserver_key => "foo", 
+        etcdpeer_crt => "foo", 
+        etcdpeer_key => "foo", 
+        etcd_peers => ["foo"], 
+        etcd_ip => "foo", 
+        etcd_initial_cluster => "foo",  
+        token => "foo",     
+        apiserver_cert_extra_sans => ["foo"],
+        apiserver_extra_arguments => ["foo"],
+        service_cidr => "10.96.0.0/12",
+        node_label => "foo",
+        cloud_provider => ":undef",
+        kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+      }' }
+    let(:params) do
+        {
+            'container_runtime' => 'docker',
+            'controller' => true,
+            'cloud_provider' => ':undef',
+            'manage_docker' => false,
+        }
+    end
+    it { should_not contain_service('docker')}
     it { should contain_service('etcd')}
   end
 end


### PR DESCRIPTION
Some people might want to use other modules or custom profiles for
configuring and installing Docker.

Using a feature flag to enable/disable the management of Docker makes the
above possible.