### PR TITLE
dont use modprobe on virtual machines like lxc

### DIFF
--- a/templates/containerd.service.erb
+++ b/templates/containerd.service.erb
@@ -4,7 +4,9 @@ Documentation=https://containerd.io
 After=network.target
 
 [Service]
+<%- unless @is_virtual -%>
 ExecStartPre=/sbin/modprobe overlay
+<%- end -%>
 ExecStart=/usr/bin/containerd
 Delegate=yes
 KillMode=process


### PR DESCRIPTION
fix for https://github.com/puppetlabs/puppetlabs-kubernetes/issues/145