### PR TITLE
Add feature flag for managing Etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,14 @@ Valid values are `true`, `false`.
 
 Defaults to `true`.
 
+#### `manage_etcd`
+
+Specifies whether to install an external Etcd via this module.
+
+Valid values are `true`, `false`.
+
+Defaults to `true`.
+
 #### `node_label`
 
 An override to the label of a node.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,7 @@
 #Calss kubernetes config, populates config files with params to bootstrap cluster
 class kubernetes::config (
 
+  Boolean $manage_etcd = $kubernetes::manage_etcd,
   String $kubernetes_version  = $kubernetes::kubernetes_version,
   String $etcd_ca_key = $kubernetes::etcd_ca_key,
   String $etcd_ca_crt = $kubernetes::etcd_ca_crt,
@@ -42,11 +43,13 @@ class kubernetes::config (
     }
   }
 
-  $etcd.each | String $etcd_files | {
-    file { "/etc/kubernetes/pki/etcd/${etcd_files}":
-      ensure  => present,
-      mode    => '0644',
-      content => template("kubernetes/etcd/${etcd_files}.erb"),
+  if $manage_etcd {
+    $etcd.each | String $etcd_files | {
+      file { "/etc/kubernetes/pki/etcd/${etcd_files}":
+        ensure  => present,
+        mode    => '0644',
+        content => template("kubernetes/etcd/${etcd_files}.erb"),
+      }
     }
   }
 
@@ -58,9 +61,11 @@ class kubernetes::config (
     }
   }
 
-  file { '/etc/systemd/system/etcd.service':
-    ensure  => present,
-    content => template('kubernetes/etcd/etcd.service.erb'),
+  if $manage_etcd {
+    file { '/etc/systemd/system/etcd.service':
+      ensure  => present,
+      content => template('kubernetes/etcd/etcd.service.erb'),
+    }
   }
 
   # to_yaml emits a complete YAML document, so we must remove the leading '---'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,10 @@
 #   Whether or not to install Docker repositories and packages via this module.
 #   Defaults to true.
 #
+# [*manage_etcd*]
+#   When set to true, etcd will be downloaded from the specified source URL.
+#   Defaults to true.
+#
 # [*kube_api_advertise_address*]
 #   This is the ip address that the want to api server to expose.
 #   An example with hiera would be kubernetes::kube_api_advertise_address: "%{::ipaddress_enp0s8}"
@@ -284,6 +288,7 @@ class kubernetes (
   Boolean $controller                                              = $kubernetes::params::controller,
   Boolean $worker                                                  = $kubernetes::params::worker,
   Boolean $manage_docker                                           = $kubernetes::params::manage_docker,
+  Boolean $manage_etcd                                             = $kubernetes::params::manage_etcd,
   Optional[String] $kube_api_advertise_address                     = $kubernetes::params::kube_api_advertise_address,
   Optional[String] $etcd_version                                   = $kubernetes::params::etcd_version,
   Optional[String] $etcd_ip                                        = $kubernetes::params::etcd_ip,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -5,6 +5,7 @@ class kubernetes::packages (
   String $kubernetes_package_version           = $kubernetes::kubernetes_package_version,
   String $container_runtime                    = $kubernetes::container_runtime,
   Boolean $manage_docker                       = $kubernetes::manage_docker,
+  Boolean $manage_etcd                         = $kubernetes::manage_etcd,
   Optional[String] $docker_version             = $kubernetes::docker_version,
   Optional[String] $docker_package_name        = $kubernetes::docker_package_name,
   Boolean $controller                          = $kubernetes::controller,
@@ -92,7 +93,7 @@ class kubernetes::packages (
     }
   }
 
-  if $controller {
+  if $controller and $manage_etcd {
     archive { $etcd_archive:
       path            => "/${etcd_archive}",
       source          => $etcd_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,7 @@ $controller = false
 $bootstrap_controller = false
 $worker =  false
 $manage_docker = true
+$manage_etcd = true
 $kube_api_advertise_address = undef
 $etcd_ip = undef
 $etcd_initial_cluster = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,7 @@ class kubernetes::service (
   String $container_runtime         = $kubernetes::container_runtime,
   Boolean $controller               = $kubernetes::controller,
   Boolean $manage_docker            = $kubernetes::manage_docker,
+  Boolean $manage_etcd              = $kubernetes::manage_etcd,
   Optional[String] $cloud_provider  = $kubernetes::cloud_provider,
 ){
   file { '/etc/systemd/system/kubelet.service.d':
@@ -60,7 +61,7 @@ class kubernetes::service (
     }
   }
 
-  if $controller {
+  if $controller and $manage_etcd {
     service { 'etcd':
       ensure  => running,
       enable  => true,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 describe 'kubernetes::config', :type => :class do
-  context 'with controller => true' do
+  context 'with controller => true and manage_etcd => true' do
     let(:params) do 
         {
         'kubernetes_version' => '1.10.2',
         'container_runtime' => 'docker',
+        'manage_etcd' => true,
         'etcd_version' => '3.1.12',
         'etcd_ca_key' => 'foo',
         'etcd_ca_crt' => 'foo', 
@@ -53,6 +54,64 @@ describe 'kubernetes::config', :type => :class do
 
 
     it { should contain_file('/etc/systemd/system/etcd.service') }
+    it { should contain_file('/etc/kubernetes/config.yaml') }
+    it { should contain_file('/etc/kubernetes/config.yaml').with_content(/foo:\n- bar\n- baz/) }
+  end
+
+  context 'with controller => true and manage_etcd => false' do
+    let(:params) do 
+        {
+        'kubernetes_version' => '1.10.2',
+        'container_runtime' => 'docker',
+        'manage_etcd' => false,
+        'etcd_version' => '3.1.12',
+        'etcd_ca_key' => 'foo',
+        'etcd_ca_crt' => 'foo', 
+        'etcdclient_key' => 'foo',
+        'etcdclient_crt' => 'foo',
+        'api_server_count' => 3,
+        'kubernetes_ca_crt' => 'foo',
+        'kubernetes_ca_key' => 'foo',
+        'discovery_token_hash' => 'foo',
+        'sa_pub' => 'foo',
+        'sa_key' => 'foo',
+        'kube_api_advertise_address' => 'foo',
+        'cni_pod_cidr' => '10.0.0.0/24',
+        'etcdserver_crt' => 'foo', 
+        'etcdserver_key' => 'foo', 
+        'etcdpeer_crt' => 'foo', 
+        'etcdpeer_key' => 'foo', 
+        'etcd_peers' => ['foo'], 
+        'etcd_ip' => 'foo', 
+        'etcd_initial_cluster' => 'foo',  
+        'token' => 'foo',     
+        'apiserver_cert_extra_sans' => ['foo'],
+        'apiserver_extra_arguments' => ['foo'],
+        'service_cidr' => '10.96.0.0/12',
+        'node_label' => 'foo',
+        'cloud_provider' => 'undef',
+        'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
+        }
+    end
+
+    kube_dirs = ['/etc/kubernetes/', '/etc/kubernetes/manifests', '/etc/kubernetes/pki', '/etc/kubernetes/pki/etcd']
+    etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key','peer.crt', 'peer.key', 'server.crt', 'server.key']
+    pki = ['ca.crt', 'ca.key','sa.pub','sa.key']
+
+    for d in kube_dirs do
+    it { should contain_file("#{d}") }
+    end
+
+    for f in etcd do
+    it { should_not contain_file("/etc/kubernetes/pki/etcd/#{f}") }
+    end
+
+    for cert in pki do
+    it { should contain_file("/etc/kubernetes/pki/#{cert}") }
+    end
+
+
+    it { should_not contain_file('/etc/systemd/system/etcd.service') }
     it { should contain_file('/etc/kubernetes/config.yaml') }
     it { should contain_file('/etc/kubernetes/config.yaml').with_content(/foo:\n- bar\n- baz/) }
   end

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 describe 'kubernetes::packages', :type => :class do
-  context 'with osfamily => RedHat and container_runtime => Docker and manage_docker => true' do
+  context 'with osfamily => RedHat and container_runtime => Docker and manage_docker => true and manage_etcd => true' do
     let(:facts) do
         {
           :lsbdistcodename  => 'xenial',
@@ -29,6 +29,7 @@ describe 'kubernetes::packages', :type => :class do
         'docker_package_name' => 'docker-engine',   
         'disable_swap' => true,
         'manage_docker' => true,
+        'manage_etcd' => true,
         }
     end
 
@@ -41,7 +42,7 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
   end
 
-  context 'with osfamily => Debian and container_runtime => cri_containerd' do
+  context 'with osfamily => Debian and container_runtime => cri_containerd and manage_etcd => false' do
     let(:facts) do
         {
           :kernel           => 'Linux',
@@ -69,20 +70,21 @@ describe 'kubernetes::packages', :type => :class do
         'docker_package_name' => 'docker-engine',  
         'disable_swap' => true,
         'manage_docker' => true,
+        'manage_etcd' => false,
         }
     end
 
     it { should contain_wget__fetch("download runc binary")}
     it { should contain_file('/usr/bin/runc')}
     it { should contain_archive('containerd-1.1.0.linux-amd64.tar.gz')}
-    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should_not contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
     it { should contain_package('kubelet').with_ensure('1.10.2-00')}
     it { should contain_package('kubectl').with_ensure('1.10.2-00')}
     it { should contain_package('kubeadm').with_ensure('1.10.2-00')}
     
   end
   
-  context 'with osfamily => Debian and container_runtime => Docker and manage_docker => false' do
+  context 'with osfamily => Debian and container_runtime => Docker and manage_docker => false and manage_etcd => true' do
     let(:facts) do
         {
           :lsbdistcodename  => 'xenial',
@@ -111,6 +113,7 @@ describe 'kubernetes::packages', :type => :class do
         'docker_package_name' => 'docker-engine',   
         'disable_swap' => true,
         'manage_docker' => false,
+        'manage_etcd' => true,
         }
     end
 
@@ -148,7 +151,8 @@ describe 'kubernetes::packages', :type => :class do
         'controller' => true, 
         'docker_package_name' => 'docker-engine',  
         'disable_swap' => true,
-        'manage_docker' => true, 
+        'manage_docker' => true,
+        'manage_etcd' => true,
         }
     end
 

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -13,10 +13,11 @@ describe 'kubernetes::service', :type => :class do
     }
   end
 
-  context 'with controller => true and container_runtime => cri_containerd' do
+  context 'with controller => true and container_runtime => cri_containerd and manage_etcd => true' do
     let(:pre_condition) { 'class {"kubernetes::config":
         kubernetes_version => "1.10.2",
         container_runtime => "cri_containerd",
+        manage_etcd => true,
         etcd_version => "3.1.12",
         etcd_ca_key => "foo",
         etcd_ca_crt => "foo", 
@@ -50,7 +51,8 @@ describe 'kubernetes::service', :type => :class do
         'container_runtime' => 'cri_containerd',
       'controller' => true,
       'cloud_provider' => ':undef',
-      'manage_docker' => true,   
+      'manage_docker' => true,
+      'manage_etcd' => true,
       }
     end
    it { should contain_file('/etc/systemd/system/kubelet.service.d')}
@@ -61,10 +63,11 @@ describe 'kubernetes::service', :type => :class do
    it { should contain_service('etcd')}
   end
 
-  context 'with controller => true and container_runtime => docker and manage_docker => true' do
+  context 'with controller => true and container_runtime => docker and manage_docker => true and manage_etcd => false' do
     let(:pre_condition) { 'class {"kubernetes::config":
         kubernetes_version => "1.10.2",
         container_runtime => "docker",
+        manage_etcd => false,
         etcd_version => "3.1.12",
         etcd_ca_key => "foo",
         etcd_ca_crt => "foo", 
@@ -99,16 +102,18 @@ describe 'kubernetes::service', :type => :class do
             'controller' => true,
             'cloud_provider' => ':undef',
             'manage_docker' => true,
+            'manage_etcd' => false,
         }
     end
     it { should contain_service('docker')}
-    it { should contain_service('etcd')}
+    it { should_not contain_service('etcd')}
   end
   
-  context 'with controller => true and container_runtime => docker and manage_docker => false' do
+  context 'with controller => true and container_runtime => docker and manage_docker => false and manage_etcd => true' do
     let(:pre_condition) { 'class {"kubernetes::config":
         kubernetes_version => "1.10.2",
         container_runtime => "docker",
+        manage_etcd => true,
         etcd_version => "3.1.12",
         etcd_ca_key => "foo",
         etcd_ca_crt => "foo", 
@@ -143,6 +148,7 @@ describe 'kubernetes::service', :type => :class do
             'controller' => true,
             'cloud_provider' => ':undef',
             'manage_docker' => false,
+            'manage_etcd' => true,
         }
     end
     it { should_not contain_service('docker')}


### PR DESCRIPTION
In some cases a custom Etcd installation or running Etcd as a deployment
in the Kubernetes cluster itself is desired.

This commit adds a feature flag for enabling/disable the installation of
an external Etcd via this module.