### PR TITLE
[Fix][Kuberneres 1.10.7] - issue with ignore-preflight-errors while workers are joining masters

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,12 @@ Valid values are `true`, `false`.
 
 Defaults to `false`.
 
+#### `ignore_preflight_errors`
+
+An array containing preflight errors options.
+
+Defaults to `[]`.
+
 ## Limitations
 
 This module supports:

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Defaults to `false`.
 
 An array containing preflight errors options.
 
-Defaults to `[]`.
+Defaults to `undef`.
 
 ## Limitations
 

--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -18,7 +18,7 @@ class kubernetes::cluster_roles (
   String $token = $kubernetes::token,
   String $discovery_token_hash = $kubernetes::discovery_token_hash,
   String $container_runtime = $kubernetes::container_runtime,
-  Optional[Array] $ignore_preflight_errors = []
+  Optional[Array] $ignore_preflight_errors = $kubernetes::ignore_preflight_errors
 
 ){
   $path = ['/usr/bin','/bin','/sbin','/usr/local/bin']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,6 +31,7 @@ class kubernetes::config (
   String $node_label = $kubernetes::node_label,
   Optional[String] $cloud_provider = $kubernetes::cloud_provider,
   Hash $kubeadm_extra_config = $kubernetes::kubeadm_extra_config,
+  Optional[Array] $ignore_preflight_errors = $kubernetes::ignore_preflight_errors,
 ) {
 
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,7 +31,6 @@ class kubernetes::config (
   String $node_label = $kubernetes::node_label,
   Optional[String] $cloud_provider = $kubernetes::cloud_provider,
   Hash $kubeadm_extra_config = $kubernetes::kubeadm_extra_config,
-  Optional[Array] $ignore_preflight_errors = $kubernetes::ignore_preflight_errors,
 ) {
 
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -270,6 +270,10 @@
 #  A flag to turn off the swap setting. This is required for kubeadm.
 #  Defaults to true
 #
+# [*ignore_preflight_errors*]
+#  A flag to turn off the swap setting. This is required for kubeadm.
+#  Defaults to true
+#
 # Authors
 # -------
 #
@@ -341,6 +345,7 @@ class kubernetes (
   Optional[String] $docker_key_source                              = $kubernetes::params::docker_key_source,
   Boolean $disable_swap                                            = $kubernetes::params::disable_swap,
   Boolean $create_repos                                            = $kubernetes::params::create_repos,
+  Optional[Array] $ignore_preflight_errors                         = $kubernetes::params::ignore_preflight_errors,
 
   )  inherits kubernetes::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,7 +272,7 @@
 #
 # [*ignore_preflight_errors*]
 #  A flag to turn off the swap setting. This is required for kubeadm.
-#  Defaults to true
+#  Defaults to undef
 #
 # Authors
 # -------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,7 +272,7 @@
 #
 # [*ignore_preflight_errors*]
 #  A flag to turn off the swap setting. This is required for kubeadm.
-#  Defaults to undef
+#  Defaults to []
 #
 # Authors
 # -------

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,4 +79,3 @@ $create_repos = true
 $disable_swap = true
 $ignore_preflight_errors = undef
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,5 +77,6 @@ $docker_key_id = '58118E89F3A912897C070ADBF76221572C52609D'
 $docker_key_source = 'https://apt.dockerproject.org/gpg'
 $create_repos = true
 $disable_swap = true
+$ignore_preflight_errors = []
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,5 +77,5 @@ $docker_key_id = '58118E89F3A912897C070ADBF76221572C52609D'
 $docker_key_source = 'https://apt.dockerproject.org/gpg'
 $create_repos = true
 $disable_swap = true
-$ignore_preflight_errors = undef
+$ignore_preflight_errors = []
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,6 +77,6 @@ $docker_key_id = '58118E89F3A912897C070ADBF76221572C52609D'
 $docker_key_source = 'https://apt.dockerproject.org/gpg'
 $create_repos = true
 $disable_swap = true
-$ignore_preflight_errors = []
+$ignore_preflight_errors = undef
 }
 

--- a/spec/classes/cluster_roles_spec.rb
+++ b/spec/classes/cluster_roles_spec.rb
@@ -34,7 +34,8 @@ describe 'kubernetes::cluster_roles', :type => :class do
           'etcd_initial_cluster' => 'foo',
           'controller_address' => '172.17.10.101',  
           'node_label' => 'foo',    
-          'container_runtime' => 'docker',     
+          'container_runtime' => 'docker',
+          'ignore_preflight_errors' => '',   
         } 
     end
 
@@ -60,6 +61,7 @@ describe 'kubernetes::cluster_roles', :type => :class do
           'controller_address' => '172.17.10.101',  
           'node_label' => 'foo',   
           'container_runtime' => 'docker',  
+          'ignore_preflight_errors' => '',  
           # 'docker_package_name' => 'docker-engine',   
         } 
     end

--- a/spec/classes/cluster_roles_spec.rb
+++ b/spec/classes/cluster_roles_spec.rb
@@ -35,7 +35,7 @@ describe 'kubernetes::cluster_roles', :type => :class do
           'controller_address' => '172.17.10.101',  
           'node_label' => 'foo',    
           'container_runtime' => 'docker',
-          'ignore_preflight_errors' => '',   
+          'ignore_preflight_errors' => ['cri'],
         } 
     end
 
@@ -61,7 +61,7 @@ describe 'kubernetes::cluster_roles', :type => :class do
           'controller_address' => '172.17.10.101',  
           'node_label' => 'foo',   
           'container_runtime' => 'docker',  
-          'ignore_preflight_errors' => '',  
+          'ignore_preflight_errors' => ['cri'],
           # 'docker_package_name' => 'docker-engine',   
         } 
     end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,6 +33,7 @@ describe 'kubernetes::config', :type => :class do
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
+        'ignore_preflight_errors' => 'undef',
         }
     end
 
@@ -91,6 +92,7 @@ describe 'kubernetes::config', :type => :class do
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
+        'ignore_preflight_errors' => 'undef',
         }
     end
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,7 +33,7 @@ describe 'kubernetes::config', :type => :class do
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
-        'ignore_preflight_errors' => 'undef',
+        'ignore_preflight_errors' => :undef,
         }
     end
 
@@ -92,7 +92,7 @@ describe 'kubernetes::config', :type => :class do
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
-        'ignore_preflight_errors' => 'undef',
+        'ignore_preflight_errors' => :undef,
         }
     end
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,7 +33,7 @@ describe 'kubernetes::config', :type => :class do
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
-        'ignore_preflight_errors' => :undef,
+        'ignore_preflight_errors' => ['cri'],
         }
     end
 
@@ -92,7 +92,7 @@ describe 'kubernetes::config', :type => :class do
         'node_label' => 'foo',
         'cloud_provider' => 'undef',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
-        'ignore_preflight_errors' => :undef,
+        'ignore_preflight_errors' => ['cri'],
         }
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,7 +45,7 @@ describe 'kubernetes', :type => :class do
         'token' => 'foo',
         'create_repos' => true,
         'disable_swap' => true,
-        'ignore_preflight_errors' => '',
+        'ignore_preflight_errors' => :undef,
         
       }
     end
@@ -80,7 +80,7 @@ describe 'kubernetes', :type => :class do
         'cloud_provider' => :undef,  
         'token' => 'foo',
         'disable_swap' => true,
-        'ignore_preflight_errors' => '',
+        'ignore_preflight_errors' => :undef,
                          
       }
     end
@@ -121,7 +121,7 @@ describe 'kubernetes', :type => :class do
         'cloud_provider' => :undef,
         'token' => 'foo',
         'disable_swap' => true,
-        'ignore_preflight_errors' => 'cri',
+        'ignore_preflight_errors' => ['cri'],
                 
       }
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,6 +45,7 @@ describe 'kubernetes', :type => :class do
         'token' => 'foo',
         'create_repos' => true,
         'disable_swap' => true,
+        'ignore_preflight_errors' => '',
         
       }
     end
@@ -79,6 +80,7 @@ describe 'kubernetes', :type => :class do
         'cloud_provider' => :undef,  
         'token' => 'foo',
         'disable_swap' => true,
+        'ignore_preflight_errors' => '',
                          
       }
     end
@@ -119,6 +121,7 @@ describe 'kubernetes', :type => :class do
         'cloud_provider' => :undef,
         'token' => 'foo',
         'disable_swap' => true,
+        'ignore_preflight_errors' => 'cri',
                 
       }
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,7 +45,7 @@ describe 'kubernetes', :type => :class do
         'token' => 'foo',
         'create_repos' => true,
         'disable_swap' => true,
-        'ignore_preflight_errors' => :undef,
+        'ignore_preflight_errors' => ['cri'],
         
       }
     end
@@ -80,7 +80,7 @@ describe 'kubernetes', :type => :class do
         'cloud_provider' => :undef,  
         'token' => 'foo',
         'disable_swap' => true,
-        'ignore_preflight_errors' => :undef,
+        'ignore_preflight_errors' => ['cri'],
                          
       }
     end


### PR DESCRIPTION
With version 3.0.1, workers failed to join masters:

`Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[worker01]/Exec[kubeadm join]/returns:      [ERROR CRI]: unable to check if the container runtime at "/var/run/dockershim.sock" is running: exit status 1
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[worker01]/Exec[kubeadm join]/returns: [preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`
Error: kubeadm join 'X.X.X.X:6443' --discovery-token-ca-cert-hash 'sha256:TOKEN_SHA256' --ignore-preflight-errors '' --token 'TOKEN' returned 2 instead of one of [0]
Error: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join[worker01]/Exec[kubeadm join]/returns: change from notrun to 0 failed: kubeadm join 'X.X.X.X:6443' --discovery-token-ca-cert-hash 'sha256:TOKEN_SHA256' --ignore-preflight-errors '' --token 'TOKEN' returned 2 instead of one of [0]
`

The socket file is present but the preflight check is failing:
`root@worker01:/var/run# ls -lrta dockershim.sock 
srwxr-xr-x 1 root root 0 oct.  16 10:40 dockershim.sock
`

So to avoid the issue, now you need to add `kubernetes::ignore_preflight_errors: ['cri']` in your yaml file if necessary