### PR TITLE
(Maint)Pinning puppet version until puppet 6 support added.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,10 @@ group :development do
   gem "rake", '~> 10.0',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('1.8.7') && Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('1.9')
 end
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
+#Temporarily commenting out ENV variable for puppet_version and hardcoding puppet version to 5.5.6 until we add puppet 6 support this is to fix ci.
+#puppet_version = ENV['PUPPET_GEM_VERSION']
+
+puppet_version = '5.5.6'
 puppet_type = gem_type(puppet_version)
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']


### PR DESCRIPTION
This PR is to pin the puppet version to 5.5.6 until puppet 6 support is added. The reason for pinning is that  the latest puppet version is being pulled and is breaking ci as we havent added support yet.