### PR TITLE
Updated stdlib version requirement to >= 4.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.19.0 < 5.0.0"
+      "version_requirement": ">= 4.20.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
MR #141 implements the usage of `to_yaml` which is introduced in stdlib version [4.20.0](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/CHANGELOG.md#supported-release-4200).

However the current metadata.json requires version 4.19.0.
