### PR TITLE
Support customized kubelet configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,12 @@ A hash containing extra configuration data to be serialised with `to_yaml` and a
 
 Defaults to `{}`.
 
+#### `kubelet_extra_config`
+
+A hash containing extra configuration data to be serialised with `to_yaml` and appended to Kubelet configuration file for the cluster. Requires DynamicKubeletConfig.
+
+Defaults to `{}`.
+
 #### `kubernetes_apt_location`
 
 The APT repo URL for the Kubernetes packages.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,6 +32,7 @@ class kubernetes::config (
   Optional[String] $cloud_provider = $kubernetes::cloud_provider,
   Optional[String] $cloud_config = $kubernetes::cloud_config,
   Optional[Hash] $kubeadm_extra_config = $kubernetes::kubeadm_extra_config,
+  Optional[Hash] $kubelet_extra_config = $kubernetes::kubelet_extra_config,
   String $image_repository = $kubernetes::image_repository,
 ) {
 
@@ -67,8 +68,17 @@ class kubernetes::config (
     }
   }
 
+  # The alpha1 schema puts Kubelet configuration in a different place.
+  $kubelet_extra_config_alpha1 = {
+    'kubeletConfiguration' => {
+      'baseConfig' => $kubelet_extra_config,
+    },
+  }
+
   # to_yaml emits a complete YAML document, so we must remove the leading '---'
   $kubeadm_extra_config_yaml = regsubst(to_yaml($kubeadm_extra_config), '^---\n', '')
+  $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')
+  $kubelet_extra_config_alpha1_yaml = regsubst(to_yaml($kubelet_extra_config_alpha1), '^---\n', '')
 
   if $kubernetes_version =~ /1.1(0|1)/ {
     $template = 'alpha1'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -215,6 +215,10 @@
 #  A hash containing extra configuration data to be serialised with `to_yaml` and appended to the config.yaml file used by kubeadm.
 #  Defaults to {}
 #
+# [*kubelet_extra_config*]
+#  A hash containing extra configuration data to be serialised with `to_yaml` and appended to Kubelet configuration file for the cluster. Requires DynamicKubeletConfig.
+#  Defaults to {}
+#
 # [*kubernetes_apt_location*]
 #  The APT repo URL for the Kubernetes packages.
 #  Defaults to https://apt.kubernetes.io
@@ -330,6 +334,7 @@ class kubernetes (
   Optional[String] $cloud_provider                                 = $kubernetes::params::cloud_provider,
   Optional[String] $cloud_config                                   = $kubernetes::params::cloud_config,
   Optional[Hash] $kubeadm_extra_config                             = $kubernetes::params::kubeadm_extra_config,
+  Optional[Hash] $kubelet_extra_config                             = $kubernetes::params::kubelet_extra_config,
   Optional[String] $runc_source                                    = $kubernetes::params::runc_source,
   Optional[String] $containerd_archive                             = $kubernetes::params::containerd_archive,
   Optional[String] $containerd_source                              = $kubernetes::params::containerd_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,7 @@ $controller_address = undef
 $cloud_provider = undef
 $cloud_config = undef
 $kubeadm_extra_config = undef
+$kubelet_extra_config = undef
 $kubernetes_apt_location = 'http://apt.kubernetes.io'
 $kubernetes_apt_release = "kubernetes-${::lsbdistcodename}"
 $kubernetes_apt_repos = 'main'

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -34,6 +34,7 @@ describe 'kubernetes::config', :type => :class do
         'cloud_provider' => 'undef',
         'cloud_config' => 'undef',        
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
+        'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
         'image_repository' => 'k8s.gcr.io',
         }
     end
@@ -58,6 +59,7 @@ describe 'kubernetes::config', :type => :class do
     it { should contain_file('/etc/systemd/system/etcd.service') }
     it { should contain_file('/etc/kubernetes/config.yaml') }
     it { should contain_file('/etc/kubernetes/config.yaml').with_content(/foo:\n- bar\n- baz/) }
+    it { should contain_file('/etc/kubernetes/config.yaml').with_content(/kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo/) }
   end
 
   context 'with controller => true and manage_etcd => false' do
@@ -94,6 +96,7 @@ describe 'kubernetes::config', :type => :class do
         'cloud_provider' => 'undef',
         'cloud_config' => 'undef',        
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
+        'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
         'image_repository' => 'k8s.gcr.io',
         }
     end
@@ -118,5 +121,6 @@ describe 'kubernetes::config', :type => :class do
     it { should_not contain_file('/etc/systemd/system/etcd.service') }
     it { should contain_file('/etc/kubernetes/config.yaml') }
     it { should contain_file('/etc/kubernetes/config.yaml').with_content(/foo:\n- bar\n- baz/) }
+    it { should contain_file('/etc/kubernetes/config.yaml').with_content(/kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo/) }
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -46,6 +46,7 @@ describe 'kubernetes::service', :type => :class do
         cloud_provider => ":undef",
         cloud_config => ":undef",        
         kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_config => {"foo" => ["bar", "baz"]},
         image_repository => "k8s.gcr.io",
       }' }
     let(:params) do
@@ -98,6 +99,7 @@ describe 'kubernetes::service', :type => :class do
         cloud_provider => ":undef",
         cloud_config => ":undef",        
         kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_config => {"foo" => ["bar", "baz"]},
         image_repository => "k8s.gcr.io",
       }' }
     let(:params) do
@@ -146,6 +148,7 @@ describe 'kubernetes::service', :type => :class do
         cloud_provider => ":undef",
         cloud_config => ":undef",        
         kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_config => {"foo" => ["bar", "baz"]},
         image_repository => "k8s.gcr.io",
       }' }
     let(:params) do

--- a/templates/config-alpha1.yaml.erb
+++ b/templates/config-alpha1.yaml.erb
@@ -40,3 +40,6 @@ cloudProvider: <%= @cloud_provider %>
 <%- if @kubeadm_extra_config  -%>
 <%= @kubeadm_extra_config_yaml %>
 <%- end -%>
+<%- if @kubelet_extra_config  -%>
+<%= @kubelet_extra_config_alpha1_yaml %>
+<%- end -%>

--- a/templates/config-alpha3.yaml.erb
+++ b/templates/config-alpha3.yaml.erb
@@ -67,3 +67,9 @@ nodeRegistration:
   criSocket: /run/containerd/containerd.sock
   <%- end -%>
 token: <%= @token %>
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+<%- if @kubelet_extra_config  -%>
+<%= @kubelet_extra_config_yaml %>
+<%- end -%>


### PR DESCRIPTION
Support is added for both the alpha1 and alpha3 config.yaml formats.
Before the alpha3 format, kubelet configuration could be added via
kubeadm_extra_config.  However, that doesn't work with the alpha3
format since kubelet configuration is passed via a separate YAML
document with kind == KubeletConfiguration:
https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3#hdr-Kubeadm_init_configuration_types