### PR TITLE
etcd version is too old for kubernetes version installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@
 #
 # [*etcd_version*]
 #   The version of etcd that you would like to use.
-#   Defaults to 3.1.12
+#   Defaults to 3.3.10
 #
 # [*etcd_archive*]
 #  The name of the etcd archive
@@ -338,8 +338,8 @@ class kubernetes (
   Optional[String] $runc_source                                    = $kubernetes::params::runc_source,
   Optional[String] $containerd_archive                             = $kubernetes::params::containerd_archive,
   Optional[String] $containerd_source                              = $kubernetes::params::containerd_source,
-  String $etcd_archive                                             = $kubernetes::params::etcd_archive,
-  String $etcd_source                                              = $kubernetes::params::etcd_source,
+  String $etcd_archive                                             = "etcd-v${etcd_version}-linux-amd64.tar.gz"
+  String $etcd_source                                              = "https://github.com/coreos/etcd/releases/download/v${etcd_version}/${etcd_archive}"
   Optional[String] $kubernetes_apt_location                        = $kubernetes::params::kubernetes_apt_location,
   Optional[String] $kubernetes_apt_release                         = $kubernetes::params::kubernetes_apt_release,
   Optional[String] $kubernetes_apt_repos                           = $kubernetes::params::kubernetes_apt_repos,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,9 +19,8 @@ $containerd_version = '1.1.0'
 $containerd_archive = "containerd-${containerd_version}.linux-amd64.tar.gz"
 $containerd_source = "https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive}"
 $docker_package_name = 'docker-engine'
-$etcd_version = '3.1.12'
-$etcd_archive = "etcd-v${etcd_version}-linux-amd64.tar.gz"
-$etcd_source = "https://github.com/coreos/etcd/releases/download/v${etcd_version}/${etcd_archive}"
+$etcd_version = '3.3.10'
+# $etcd_archive and $etcd_source are set in init.pp to allow adjustment by the version
 $runc_version = '1.0.0-rc5'
 $runc_source = "https://github.com/opencontainers/runc/releases/download/v${runc_version}/runc.amd64"
 $kubernetes_fqdn = 'kubernetes'

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -22,8 +22,7 @@ describe 'kubernetes::packages', :type => :class do
         'docker_version' => '17.03.1.ce-1.el7.centos',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
-        'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
-        'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
+        'etcd_version' => 'v3.3.10',
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',   
@@ -36,7 +35,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_exec('set up bridge-nf-call-iptables')}
     it { should contain_file_line('set 1 /proc/sys/net/bridge/bridge-nf-call-iptables')}
     it { should contain_package('docker-engine').with_ensure('17.03.1.ce-1.el7.centos')}
-    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should contain_archive('etcd-v3.3.10-linux-amd64.tar.gz')
+           .with_source('https://github.com/coreos/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz')}
     it { should contain_package('kubelet').with_ensure('1.10.2')}
     it { should contain_package('kubectl').with_ensure('1.10.2')}
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
@@ -106,8 +106,7 @@ describe 'kubernetes::packages', :type => :class do
         'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
-        'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
-        'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
+        'etcd_version' => 'v3.3.1',
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',   
@@ -117,7 +116,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
 
-    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should contain_archive('etcd-v3.3.1-linux-amd64.tar.gz')} # based on etcd_version
     it { should contain_package('kubelet').with_ensure('1.10.2')}
     it { should contain_package('kubectl').with_ensure('1.10.2')}
     it { should contain_package('kubeadm').with_ensure('1.10.2')}


### PR DESCRIPTION
The default configuration doesn't work because the default etcd version is too old for the version of kubernetes selected by default.

```
 this version of kubeadm only supports external etcd version >= 3.2.18. Current version: 3.1.12
```

Fix a violation of expectations where changing the `$kubernetes::etcd_version` value had no effect since the manifests only used derived values.