### PR TITLE
adding in ordering for sysctl to present failures

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -31,7 +31,7 @@ class kubernetes::packages (
   }
 
   if $manage_kernel_modules {
-    kmod::load { 'br_netfilter': 
+    kmod::load { 'br_netfilter':
       before => Sysctl['net.bridge.bridge-nf-call-iptables'],
     }
   }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -31,13 +31,16 @@ class kubernetes::packages (
   }
 
   if $manage_kernel_modules {
-    kmod::load { 'br_netfilter': }
+    kmod::load { 'br_netfilter': 
+      before => Sysctl['net.bridge.bridge-nf-call-iptables'],
+    }
   }
 
   if $manage_sysctl_settings {
     sysctl { 'net.bridge.bridge-nf-call-iptables':
       ensure => present,
       value  => '1',
+      before => Sysctl['net.ipv4.ip_forward'],
     }
     sysctl { 'net.ipv4.ip_forward':
       ensure => present,

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -44,6 +44,10 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-translate', '--version', '1.0.0' ), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppet-archive'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppet-wget'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'herculesteam-augeasproviders_sysctl'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'herculesteam-augeasproviders_core'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'camptocamp-kmod'), { :acceptable_exit_codes => [0,1] }
+
 
       # shell('echo "#{vmhostname}" > /etc/hostname')
       # shell("hostname #{vmhostname}")
@@ -99,7 +103,7 @@ EOS
 :hierarchy:
   - "%{::hostname}"
   - "%{::osfamily}"
-:yaml:  
+:yaml:
   :datadir: /etc/puppetlabs/code/environments/production/hieradata
 EOS
 
@@ -137,7 +141,7 @@ EOS
         create_remote_file(host, "/tmp/nginx.yml", nginx)
         create_remote_file(host,"/etc/puppetlabs/puppet/hiera.yaml", hiera)
         on(host, 'cp /etc/puppetlabs/code/modules/kubernetes/tooling/*.yaml /etc/puppetlabs/code/environments/production/hieradata/', acceptable_exit_codes: [0]).stdout
-        
+
 
         if fact('osfamily') == 'Debian'
           on(host, 'sed -i /cni_network_provider/d /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout


### PR DESCRIPTION
Prevents failures where sysctl was being run in the catalog before the kernel module was loaded. 