### PR TITLE
pass node_label to node_name for init/join

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -41,6 +41,7 @@ class kubernetes::cluster_roles (
       path                    => $path,
       env                     => $env_controller,
       node_label              => $node_label,
+      node_name               => $node_label,
       ignore_preflight_errors => $preflight_errors,
       }
     }
@@ -54,6 +55,7 @@ class kubernetes::cluster_roles (
       ca_cert_hash            => $discovery_token_hash,
       cri_socket              => $cri_socket,
       node_label              => $node_label,
+      node_name               => $node_label,
       ignore_preflight_errors => $preflight_errors,
       }
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -76,6 +76,20 @@ class kubernetes::config (
     },
   }
 
+  # Need to merge the cloud configuration parameters into extra_arguments
+  if $cloud_provider {
+    $cloud_args = $cloud_config ? {
+      undef   => ["cloud-provider: ${cloud_provider}"],
+      default => ["cloud-provider: ${cloud_provider}", "cloud-config: ${cloud_config}"],
+    }
+    $apiserver_merged_extra_arguments = concat($apiserver_extra_arguments, $cloud_args)
+    $kubelet_merged_extra_arguments = concat($kubelet_extra_arguments, $cloud_args)
+    $controllermanager_merged_extra_arguments = $cloud_args
+  }
+  else {
+    $controllermanager_merged_extra_arguments = []
+  }
+
   # to_yaml emits a complete YAML document, so we must remove the leading '---'
   $kubeadm_extra_config_yaml = regsubst(to_yaml($kubeadm_extra_config), '^---\n', '')
   $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -31,8 +31,8 @@ describe 'kubernetes::config', :type => :class do
         'apiserver_extra_arguments' => ['foo'],
         'service_cidr' => '10.96.0.0/12',
         'node_label' => 'foo',
-        'cloud_provider' => 'undef',
-        'cloud_config' => 'undef',        
+        'cloud_provider' => '',
+        'cloud_config' => '',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
         'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
         'kubelet_extra_arguments' => ['foo'],
@@ -94,8 +94,8 @@ describe 'kubernetes::config', :type => :class do
         'apiserver_extra_arguments' => ['foo'],
         'service_cidr' => '10.96.0.0/12',
         'node_label' => 'foo',
-        'cloud_provider' => 'undef',
-        'cloud_config' => 'undef',        
+        'cloud_provider' => '',
+        'cloud_config' => '',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
         'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
         'kubelet_extra_arguments' => ['foo'],
@@ -124,5 +124,50 @@ describe 'kubernetes::config', :type => :class do
     it { should contain_file('/etc/kubernetes/config.yaml') }
     it { should contain_file('/etc/kubernetes/config.yaml').with_content(/foo:\n- bar\n- baz/) }
     it { should contain_file('/etc/kubernetes/config.yaml').with_content(/kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo/) }
+  end
+
+  context 'with version = 1.12 and cloud_provider => aws and cloud_config => undef' do
+    let(:params) do
+        {
+        'kubernetes_version' => '1.12.2',
+        'container_runtime' => 'docker',
+        'manage_etcd' => true,
+        'etcd_version' => '3.3.10',
+        'etcd_ca_key' => 'foo',
+        'etcd_ca_crt' => 'foo',
+        'etcdclient_key' => 'foo',
+        'etcdclient_crt' => 'foo',
+        'api_server_count' => 3,
+        'kubernetes_ca_crt' => 'foo',
+        'kubernetes_ca_key' => 'foo',
+        'discovery_token_hash' => 'foo',
+        'sa_pub' => 'foo',
+        'sa_key' => 'foo',
+        'kube_api_advertise_address' => 'foo',
+        'cni_pod_cidr' => '10.0.0.0/24',
+        'etcdserver_crt' => 'foo',
+        'etcdserver_key' => 'foo',
+        'etcdpeer_crt' => 'foo',
+        'etcdpeer_key' => 'foo',
+        'etcd_peers' => ['foo'],
+        'etcd_ip' => 'foo',
+        'etcd_initial_cluster' => 'foo',
+        'token' => 'foo',
+        'apiserver_cert_extra_sans' => ['foo'],
+        'apiserver_extra_arguments' => ['foo'],
+        'service_cidr' => '10.96.0.0/12',
+        'node_label' => 'foo',
+        'cloud_provider' => 'aws',
+        'cloud_config' => '',
+        'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
+        'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
+        'kubelet_extra_arguments' => ['foo: bar'],
+        'image_repository' => 'k8s.gcr.io',
+        }
+    end
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+       .with_content(/nodeRegistration:\n  name: foo\n  kubeletExtraArgs:\n    foo: bar\n    cloud-provider: aws\n/)
+    }
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -46,8 +46,8 @@ describe 'kubernetes::service', :type => :class do
         apiserver_extra_arguments => ["foo"],
         service_cidr => "10.96.0.0/12",
         node_label => "foo",
-        cloud_provider => ":undef",
-        cloud_config => ":undef",
+        cloud_provider => "",
+        cloud_config => "",
         kubeadm_extra_config => {"foo" => ["bar", "baz"]},
         kubelet_extra_config => {"foo" => ["bar", "baz"]},
         kubelet_extra_arguments => ["foo"],
@@ -55,9 +55,11 @@ describe 'kubernetes::service', :type => :class do
       }' }
     let(:params) do
       {
+        'kubernetes_version' => '1.10.2',
         'container_runtime' => 'cri_containerd',
         'controller' => true,
-        'cloud_provider' => ':undef',
+        'cloud_provider' => '',
+        'cloud_config' => '',
         'manage_docker' => true,
         'manage_etcd' => true,
       }
@@ -65,6 +67,7 @@ describe 'kubernetes::service', :type => :class do
    it { should contain_file('/etc/systemd/system/kubelet.service.d')}
    it { should contain_file('/etc/systemd/system/kubelet.service.d/0-containerd.conf')}
    it { should contain_file('/etc/systemd/system/containerd.service')}
+   it { is_expected.to_not contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf')}
    it { should contain_exec('kubernetes-systemd-reload')}
    it { should contain_service('containerd')}
    it { should contain_service('etcd')}
@@ -102,8 +105,8 @@ describe 'kubernetes::service', :type => :class do
         apiserver_extra_arguments => ["foo"],
         service_cidr => "10.96.0.0/12",
         node_label => "foo",
-        cloud_provider => ":undef",
-        cloud_config => ":undef",
+        cloud_provider => "",
+        cloud_config => "",
         kubeadm_extra_config => {"foo" => ["bar", "baz"]},
         kubelet_extra_config => {"foo" => ["bar", "baz"]},
         kubelet_extra_arguments => ["foo"],
@@ -111,9 +114,11 @@ describe 'kubernetes::service', :type => :class do
       }' }
     let(:params) do
       {
+        'kubernetes_version' => '1.10.2',
         'container_runtime' => 'docker',
         'controller' => true,
-        'cloud_provider' => ':undef',
+        'cloud_provider' => '',
+        'cloud_config' => '',
         'manage_docker' => true,
         'manage_etcd' => false,
       }
@@ -154,8 +159,8 @@ describe 'kubernetes::service', :type => :class do
         apiserver_extra_arguments => ["foo"],
         service_cidr => "10.96.0.0/12",
         node_label => "foo",
-        cloud_provider => ":undef",
-        cloud_config => ":undef",
+        cloud_provider => "",
+        cloud_config => "",
         kubeadm_extra_config => {"foo" => ["bar", "baz"]},
         kubelet_extra_config => {"foo" => ["bar", "baz"]},
         kubelet_extra_arguments => ["foo"],
@@ -163,9 +168,11 @@ describe 'kubernetes::service', :type => :class do
       }' }
     let(:params) do
         {
+            'kubernetes_version' => '1.10.2',
             'container_runtime' => 'docker',
             'controller' => true,
-            'cloud_provider' => ':undef',
+            'cloud_provider' => '',
+            'cloud_config' => '',
             'manage_docker' => false,
             'manage_etcd' => true,
         }
@@ -173,5 +180,168 @@ describe 'kubernetes::service', :type => :class do
     it { should_not contain_service('docker')}
     it { should contain_service('etcd')}
     it { should contain_service('kubelet')}
+  end
+
+  context 'with version => 1.10 and cloud_provider => aws and cloud_config => undef' do
+    let(:pre_condition) { 'class {"kubernetes::config":
+        kubernetes_version => "1.10.2",
+        container_runtime => "docker",
+        manage_etcd => true,
+        etcd_version => "3.1.12",
+        etcd_ca_key => "foo",
+        etcd_ca_crt => "foo",
+        etcdclient_key => "foo",
+        etcdclient_crt => "foo",
+        api_server_count => 3,
+        kubernetes_ca_crt => "foo",
+        kubernetes_ca_key => "foo",
+        discovery_token_hash => "foo",
+        sa_pub => "foo",
+        sa_key => "foo",
+        kube_api_advertise_address => "foo",
+        cni_pod_cidr => "10.0.0.0/24",
+        etcdserver_crt => "foo",
+        etcdserver_key => "foo",
+        etcdpeer_crt => "foo",
+        etcdpeer_key => "foo",
+        etcd_peers => ["foo"],
+        etcd_ip => "foo",
+        etcd_initial_cluster => "foo",
+        token => "foo",
+        apiserver_cert_extra_sans => ["foo"],
+        apiserver_extra_arguments => ["foo"],
+        service_cidr => "10.96.0.0/12",
+        node_label => "foo",
+        cloud_provider => "aws",
+        cloud_config => "",
+        kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_arguments => ["foo"],
+        image_repository => "k8s.gcr.io",
+      }' }
+    let(:params) do
+        {
+            'kubernetes_version' => '1.10.2',
+            'container_runtime' => 'docker',
+            'controller' => true,
+            'manage_docker' => true,
+            'manage_etcd' => true,
+            'cloud_provider' => 'aws',
+            'cloud_config' => '',
+        }
+    end
+    it { is_expected.to contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf') \
+      .with_content(/--cloud-provider=aws/)
+    }
+    it { is_expected.to_not contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf') \
+      .with_content(/--cloud-config=/)
+    }
+  end
+
+  context 'with version => 1.10 and cloud_provider => openstack and cloud_config => /etc/kubernetes/cloud.conf' do
+    let(:pre_condition) { 'class {"kubernetes::config":
+        kubernetes_version => "1.10.2",
+        container_runtime => "docker",
+        manage_etcd => true,
+        etcd_version => "3.1.12",
+        etcd_ca_key => "foo",
+        etcd_ca_crt => "foo",
+        etcdclient_key => "foo",
+        etcdclient_crt => "foo",
+        api_server_count => 3,
+        kubernetes_ca_crt => "foo",
+        kubernetes_ca_key => "foo",
+        discovery_token_hash => "foo",
+        sa_pub => "foo",
+        sa_key => "foo",
+        kube_api_advertise_address => "foo",
+        cni_pod_cidr => "10.0.0.0/24",
+        etcdserver_crt => "foo",
+        etcdserver_key => "foo",
+        etcdpeer_crt => "foo",
+        etcdpeer_key => "foo",
+        etcd_peers => ["foo"],
+        etcd_ip => "foo",
+        etcd_initial_cluster => "foo",
+        token => "foo",
+        apiserver_cert_extra_sans => ["foo"],
+        apiserver_extra_arguments => ["foo"],
+        service_cidr => "10.96.0.0/12",
+        node_label => "foo",
+        cloud_provider => "openstack",
+        cloud_config => "/etc/kubernetes/cloud.conf",
+        kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_arguments => ["foo"],
+        image_repository => "k8s.gcr.io",
+      }' }
+    let(:params) do
+        {
+            'kubernetes_version' => '1.10.2',
+            'container_runtime' => 'docker',
+            'controller' => true,
+            'manage_docker' => true,
+            'manage_etcd' => true,
+            'cloud_provider' => 'openstack',
+            'cloud_config' => '/etc/kubernetes/cloud.conf',
+        }
+    end
+    it { is_expected.to contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf') \
+      .with_content(/--cloud-provider=openstack/)
+    }
+    it { is_expected.to contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf') \
+      .with_content(%r|--cloud-config=/etc/kubernetes/cloud.conf|)
+    }
+  end
+
+  context 'with version => 1.12 and cloud_provider => aws' do
+    let(:pre_condition) { 'class {"kubernetes::config":
+        kubernetes_version => "1.12.3",
+        container_runtime => "docker",
+        manage_etcd => true,
+        etcd_version => "3.3.10",
+        etcd_ca_key => "foo",
+        etcd_ca_crt => "foo",
+        etcdclient_key => "foo",
+        etcdclient_crt => "foo",
+        api_server_count => 3,
+        kubernetes_ca_crt => "foo",
+        kubernetes_ca_key => "foo",
+        discovery_token_hash => "foo",
+        sa_pub => "foo",
+        sa_key => "foo",
+        kube_api_advertise_address => "foo",
+        cni_pod_cidr => "10.0.0.0/24",
+        etcdserver_crt => "foo",
+        etcdserver_key => "foo",
+        etcdpeer_crt => "foo",
+        etcdpeer_key => "foo",
+        etcd_peers => ["foo"],
+        etcd_ip => "foo",
+        etcd_initial_cluster => "foo",
+        token => "foo",
+        apiserver_cert_extra_sans => ["foo"],
+        apiserver_extra_arguments => ["foo"],
+        service_cidr => "10.96.0.0/12",
+        node_label => "foo",
+        cloud_provider => "aws",
+        cloud_config => "",
+        kubeadm_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_config => {"foo" => ["bar", "baz"]},
+        kubelet_extra_arguments => ["foo"],
+        image_repository => "k8s.gcr.io",
+      }' }
+    let(:params) do
+        {
+            'kubernetes_version' => '1.12.3',
+            'container_runtime' => 'docker',
+            'controller' => true,
+            'manage_docker' => true,
+            'manage_etcd' => true,
+            'cloud_provider' => 'aws',
+            'cloud_config' => '',
+        }
+    end
+    it { is_expected.to_not contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf')}
   end
 end

--- a/templates/20-cloud.conf.erb
+++ b/templates/20-cloud.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--cloud-provider=<%= scope['kubernetes::cloud_provider'] %> --cloud-config=/etc/kubernetes/cloud-config"
+Environment="KUBELET_EXTRA_ARGS=<%= @kubelet_extra_args %>"

--- a/templates/config-alpha3.yaml.erb
+++ b/templates/config-alpha3.yaml.erb
@@ -17,13 +17,9 @@ nodeRegistration:
   <%- if @container_runtime == "cri_containerd" -%>
   criSocket: /run/containerd/containerd.sock
   <%- end -%>
-  <%- if @cloud_provider  -%>
-  cloudProvider: <%= @cloud_provider %>
-  cloudConfig: <%= @cloud_config %>
-  <%- end -%>
-  <%- if @kubelet_extra_arguments -%>
+  <%- if @kubelet_merged_extra_arguments -%>
   kubeletExtraArgs:
-    <%- @kubelet_extra_arguments.each do |arg| -%>
+    <%- @kubelet_merged_extra_arguments.each do |arg| -%>
     <%= arg %>
     <%- end -%>
   <%- end -%>
@@ -46,18 +42,23 @@ kind: ClusterConfiguration
 kubernetesVersion: v<%= @kubernetes_version %>
 networking:
   podSubnet: <%= @cni_pod_cidr %>
-<%- if @apiserver_extra_arguments -%>
+<%- if @apiserver_merged_extra_arguments -%>
 apiServerExtraArgs:
-  <%- @apiserver_extra_arguments.each do |arg| -%>
+  <%- @apiserver_merged_extra_arguments.each do |arg| -%>
   <%= arg %>
   <%- end -%>
 <%- end -%>
-<%- if @cloud_provider  -%>
-cloudProvider: <%= @cloud_provider %>
+<%- if @controllermanager_merged_extra_arguments -%>
+controllerManagerExtraArgs:
+  <%- @controllermanager_merged_extra_arguments.each do |arg| -%>
+  <%= arg %>
+  <%- end -%>
 <%- end -%>
+<% if @apiserver_cert_extra_sans -%>
 apiServerCertSANs:
 <% @apiserver_cert_extra_sans.each do |san| -%>
 - <%= san %>
+<% end -%>
 <% end -%>
 <%- if @kubeadm_extra_config  -%>
 <%= @kubeadm_extra_config_yaml %>
@@ -70,9 +71,9 @@ nodeRegistration:
   <%- if @container_runtime == "cri_containerd" -%>
   criSocket: /run/containerd/containerd.sock
   <%- end -%>
-  <%- if @kubelet_extra_arguments -%>
+  <%- if @kubelet_merged_extra_arguments -%>
   kubeletExtraArgs:
-    <%- @kubelet_extra_arguments.each do |arg| -%>
+    <%- @kubelet_merged_extra_arguments.each do |arg| -%>
     <%= arg %>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
I'm not certain what the logic is, but there's an initialized input `node_name` which is now being passed to init/join which isn't set by anything. This doesn't work for AWS environments because we must pass in the hostname from instance data.

The attached patch solves the problem for me, but it's a hack. What's the difference between `node_name` and `node_label`? What was the goal here? 

For AWS I need to send you a patch that overrides the hostname with the instance name anyway, for this reason:

```
19s         Normal    RegisteredNode             Node        Node normalhostname.example.com event: Registered Node normalhostname.example.com in Controller
18s         Normal    DeletingNode               Node        Node normalhostname.example.com event: Deleting Node normalhostname.example.com because it's not present according to cloud provider
```