### PR TITLE
Build config file for worker nodes too

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -1,26 +1,12 @@
 # This class configures the RBAC roles for Kubernetes 1.10.x
 
 class kubernetes::cluster_roles (
-
-  Optional[String] $controller_address = $kubernetes::controller_address,
   Optional[Boolean] $controller = $kubernetes::controller,
   Optional[Boolean] $worker = $kubernetes::worker,
-  Optional[String] $etcd_ip = $kubernetes::etcd_ip,
-  Optional[String] $etcd_initial_cluster = $kubernetes::etcd_initial_cluster,
   String $node_name = $kubernetes::node_name,
-  String $etcd_ca_key = $kubernetes::etcd_ca_key,
-  String $etcd_ca_crt = $kubernetes::etcd_ca_crt,
-  String $etcdclient_key = $kubernetes::etcdclient_key,
-  String $etcdclient_crt = $kubernetes::etcdclient_crt,
-  String $kube_api_advertise_address = $kubernetes::kube_api_advertise_address,
-  Integer $api_server_count = $kubernetes::api_server_count,
-  String $cni_pod_cidr = $kubernetes::cni_pod_cidr,
-  String $token = $kubernetes::token,
-  String $discovery_token_hash = $kubernetes::discovery_token_hash,
   String $container_runtime = $kubernetes::container_runtime,
   Optional[Array] $ignore_preflight_errors = []
-
-){
+) {
   $path = ['/usr/bin','/bin','/sbin','/usr/local/bin']
   $env_controller = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf']
   #Worker nodes do not have admin.conf present
@@ -37,10 +23,8 @@ class kubernetes::cluster_roles (
 
   if $controller {
     kubernetes::kubeadm_init { $node_name:
-      config                  => '/etc/kubernetes/config.yaml',
       path                    => $path,
       env                     => $env_controller,
-      node_name               => $node_name,
       ignore_preflight_errors => $preflight_errors,
       }
     }
@@ -49,12 +33,8 @@ class kubernetes::cluster_roles (
     kubernetes::kubeadm_join { $node_name:
       path                    => $path,
       env                     => $env_worker,
-      controller_address      => $controller_address,
-      token                   => $token,
-      ca_cert_hash            => $discovery_token_hash,
       cri_socket              => $cri_socket,
-      node_name               => $node_name,
       ignore_preflight_errors => $preflight_errors,
-      }
     }
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 #Calss kubernetes config, populates config files with params to bootstrap cluster
 class kubernetes::config (
-
+  String $config_file = $kubernetes::config_file,
   Boolean $manage_etcd = $kubernetes::manage_etcd,
   String $kubernetes_version  = $kubernetes::kubernetes_version,
   String $etcd_ca_key = $kubernetes::etcd_ca_key,
@@ -115,7 +115,7 @@ class kubernetes::config (
     $template = 'alpha3'
   }
 
-  file { '/etc/kubernetes/config.yaml':
+  file { $config_file:
     ensure  => present,
     content => template("kubernetes/config-${template}.yaml.erb"),
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -85,9 +85,23 @@ class kubernetes::config (
     $apiserver_merged_extra_arguments = concat($apiserver_extra_arguments, $cloud_args)
     $kubelet_merged_extra_arguments = concat($kubelet_extra_arguments, $cloud_args)
     $controllermanager_merged_extra_arguments = $cloud_args
+
+    # could check against Kubernetes 1.10 here, but that uses alpha1 config which doesn't have these options
+    if $cloud_config {
+      # The cloud config must be mounted into the apiserver and controllermanager containers
+      $controllermanager_extra_volumes = $apiserver_extra_volumes = {
+        'cloud' => {
+          hostPath  => $cloud_config,
+          mountPath => $cloud_config,
+        }
+      }
+    }
   }
   else {
+    $apiserver_merged_extra_arguments = $apiserver_extra_arguments
+    $apiserver_extra_volumes = {}
     $controllermanager_merged_extra_arguments = []
+    $controllermanager_extra_volumes = {}
   }
 
   # to_yaml emits a complete YAML document, so we must remove the leading '---'

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -1,0 +1,47 @@
+# Class kubernetes config_worker, populates worker config files with joinconfig
+class kubernetes::config::worker (
+  String $node_name                        = $kubernetes::node_name,
+  String $config_file                      = $kubernetes::config_file,
+  String $kubernetes_version               = $kubernetes::kubernetes_version,
+  String $controller_address               = $kubernetes::controller_address,
+  String $discovery_token_hash             = $kubernetes::discovery_token_hash,
+  String $container_runtime                = $kubernetes::container_runtime,
+  String $discovery_token                  = $kubernetes::token,
+  String $tls_bootstrap_token              = $kubernetes::token,
+  String $token                            = $kubernetes::token,
+  Optional[String] $discovery_file         = undef,
+  Optional[String] $feature_gates          = undef,
+  Optional[String] $cloud_provider         = $kubernetes::cloud_provider,
+  Optional[String] $cloud_config           = $kubernetes::cloud_config,
+  Optional[Array] $kubelet_extra_arguments = $kubernetes::kubelet_extra_arguments,
+  Optional[Hash] $kubelet_extra_config     = $kubernetes::kubelet_extra_config,
+  Optional[Array] $ignore_preflight_errors = undef,
+  Boolean $skip_ca_verification            = false,
+) {
+  # Need to merge the cloud configuration parameters into extra_arguments
+  if !empty($cloud_provider) {
+    $cloud_args = empty($cloud_config) ? {
+      true    => ["cloud-provider: ${cloud_provider}"],
+      default => ["cloud-provider: ${cloud_provider}", "cloud-config: ${cloud_config}"],
+    }
+    $kubelet_merged_extra_arguments = concat($kubelet_extra_arguments, $cloud_args)
+  }
+  else {
+    $kubelet_merged_extra_arguments = $kubelet_extra_arguments
+  }
+
+  # to_yaml emits a complete YAML document, so we must remove the leading '---'
+  $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')
+
+  $template = $kubernetes_version ? {
+    default => 'v1alpha3',
+  }
+
+  file { $config_file:
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template("kubernetes/${template}/config_worker.yaml.erb"),
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -412,6 +412,9 @@ class kubernetes (
     }
   }
 
+  # Not sure if should allow this to be changed
+  $config_file = '/etc/kubernetes/config.yaml'
+
   if $controller {
     include kubernetes::repos
     include kubernetes::packages
@@ -435,12 +438,13 @@ class kubernetes (
   }
 
   if $worker {
-    include kubernetes::repos
-    include kubernetes::packages
-    include kubernetes::service
-    include kubernetes::cluster_roles
     contain kubernetes::repos
     contain kubernetes::packages
+    # K8s 1.10/1.11 can't use config files
+    unless $kubernetes_version =~ /^1.1(0|1)/ {
+      contain kubernetes::config::worker
+      Class['kubernetes::config::worker'] -> Class['kubernetes::service']
+    }
     contain kubernetes::service
     contain kubernetes::cluster_roles
 

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -1,46 +1,17 @@
 # == kubernetes::kubeadm_init
 define kubernetes::kubeadm_init (
   String $node_name                             = $kubernetes::node_name,
-  Optional[String] $apiserver_advertise_address = undef,
-  Optional[Integer] $apiserver_bind_port        = undef,
-  Optional[Array] $apiserver_cert_extra_sans    = undef,
-  Optional[String] $cert_dir                    = undef,
-  Optional[String] $config                      = undef,
-  Optional[String] $cri_socket                  = undef,
+  Optional[String] $config                      = $kubernetes::config_file,
   Boolean $dry_run                              = false,
   Optional[Array] $env                          = undef,
-  Optional[Array] $feature_gates                = undef,
-  Optional[Array] $ignore_preflight_errors      = undef,
-  Optional[String] $kubernetes_version          = undef,
-  Optional[String] $pod_network_cidr            = undef,
-  Optional[String] $service_cidr                = undef,
-  Optional[String] $service_dns_domain          = undef,
   Optional[Array] $path                         = undef,
-  Boolean $skip_token_print                     = false,
-  Optional[String] $token                       = undef,
-  Optional[String] $token_ttl                   = undef,
+  Optional[Array] $ignore_preflight_errors      = undef,
 ) {
-
   $kubeadm_init_flags = kubeadm_init_flags({
-    apiserver_advertise_address => $apiserver_advertise_address,
-    apiserver_bind_port         => $apiserver_bind_port,
-    apiserver_cert_extra_sans   => $apiserver_cert_extra_sans,
-    cert_dir                    => $cert_dir,
-    config                      => $config,
-    cri_socket                  => $cri_socket,
-    dry_run                     => $dry_run,
-    feature_gates               => $feature_gates,
-    ignore_preflight_errors     => $ignore_preflight_errors,
-    kubernetes_version          => $kubernetes_version,
-    node_name                   => $node_name,
-    pod_network_cidr            => $pod_network_cidr,
-    service_cidr                => $service_cidr,
-    service_dns_domain          => $service_dns_domain,
-    skip_token_print            => $skip_token_print,
-    token_ttl                   => $token_ttl,
-    token                       => $token,
+    config                  => $config,
+    dry_run                 => $dry_run,
+    ignore_preflight_errors => $ignore_preflight_errors,
   })
-
 
   $exec_init = "kubeadm init ${kubeadm_init_flags}"
   $unless_init = "kubectl get nodes | grep ${node_name}"

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -1,36 +1,49 @@
 # == kubernetes::kubeadm_join
 define kubernetes::kubeadm_join (
   String $node_name                        = $kubernetes::node_name,
-String $controller_address               = undef,
-Optional[String] $ca_cert_hash           = undef,
-Optional[String] $config                 = undef,
-Optional[String] $cri_socket             = undef,
-Optional[String] $discovery_file         = undef,
-Optional[String] $discovery_token        = undef,
-Optional[Array] $env                     = undef,
-Optional[String] $feature_gates          = undef,
-Optional[Array] $ignore_preflight_errors = undef,
-Optional[Array] $path                    = undef,
-Boolean $skip_ca_verification            = false,
-Optional[String] $tls_bootstrap_token    = undef,
-Optional[String] $token                  = undef
+  String $kubernetes_version               = $kubernetes::kubernetes_version,
+  String $config                           = $kubernetes::config_file,
+  String $controller_address               = $kubernetes::controller_address,
+  String $ca_cert_hash                     = $kubernetes::discovery_token_hash,
+  String $discovery_token                  = $kubernetes::token,
+  String $tls_bootstrap_token              = $kubernetes::token,
+  String $token                            = $kubernetes::token,
+  Optional[String] $feature_gates          = undef,
+  Optional[String] $cri_socket             = undef,
+  Optional[String] $discovery_file         = undef,
+  Optional[Array] $env                     = undef,
+  Optional[Array] $ignore_preflight_errors = undef,
+  Optional[Array] $path                    = undef,
+  Boolean $skip_ca_verification            = false,
 ) {
 
-  $kubeadm_join_flags = kubeadm_join_flags({
-    controller_address       => $controller_address,
-    config                   => $config,
-    cri_socket               => $cri_socket,
-    discovery_file           => $discovery_file,
-    discovery_token          => $discovery_token,
-    ca_cert_hash             => $ca_cert_hash,
-    skip_ca_verification     => $skip_ca_verification,
-    feature_gates            => $feature_gates,
-    ignore_preflight_errors  => $ignore_preflight_errors,
-    node_name                => $node_name,
-    tls_bootstrap_token      => $tls_bootstrap_token,
-    token                    => $token
-  })
-
+  case $kubernetes_version {
+    # K1.11 and below don't use the config file
+    /^1.1(0|1)/: {
+      $kubeadm_join_flags = kubeadm_join_flags({
+        controller_address       => $controller_address,
+        config                   => $config,
+        cri_socket               => $cri_socket,
+        discovery_file           => $discovery_file,
+        discovery_token          => $discovery_token,
+        ca_cert_hash             => $ca_cert_hash,
+        skip_ca_verification     => $skip_ca_verification,
+        feature_gates            => $feature_gates,
+        ignore_preflight_errors  => $ignore_preflight_errors,
+        node_name                => $node_name,
+        tls_bootstrap_token      => $tls_bootstrap_token,
+        token                    => $token
+      })
+    }
+    default: {
+      $kubeadm_join_flags = kubeadm_join_flags({
+        config                   => $config,
+        discovery_file           => $discovery_file,
+        feature_gates            => $feature_gates,
+        ignore_preflight_errors  => $ignore_preflight_errors,
+      })
+    }
+  }
 
   $exec_join = "kubeadm join ${kubeadm_join_flags}"
   $unless_join = "kubectl get nodes | grep ${node_name}"

--- a/spec/classes/config/worker_spec.rb
+++ b/spec/classes/config/worker_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+describe 'kubernetes::config::worker', :type => :class do
+  let(:pre_condition) { 'include kubernetes' }
+  let(:facts) do
+    {
+      :kernel => 'Linux',
+      :networking => {
+        :hostname => 'foo',
+      },
+      :os => {
+        :family => 'Debian',
+        :name => 'Ubuntu',
+        :release => {
+          :full => '16.04',
+        },
+        :distro => {
+          :codename => 'xenial',
+        },
+      },
+      :ec2_metadata => {
+        :hostname => 'ip-10-10-10-1.ec2.internal',
+      },
+    }
+  end
+
+  context 'with version => 1.12.3 cloud_provider => undef' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.12.3',
+        'kubelet_extra_arguments' => ['foo'],
+      }
+    end
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{apiVersion: kubeadm.k8s.io/v1alpha3\n}) }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{  kubeletExtraArgs:\n    foo\n}) }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').without_content(%r{cloud-provider}) }
+  end
+
+  context 'with version => 1.12.3 cloud_provider => aws' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.12.3',
+        'cloud_provider' => 'aws',
+      }
+    end
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{apiVersion: kubeadm.k8s.io/v1alpha3\n}) }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{  kubeletExtraArgs:\n    cloud-provider: aws\n}) }
+  end
+end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -62,7 +62,6 @@ describe 'kubernetes::config', :type => :class do
     let(:params) do 
         {
         'manage_etcd' => false,
-        'cloud_config' => '',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
         'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
         'kubelet_extra_arguments' => ['foo'],
@@ -95,16 +94,35 @@ describe 'kubernetes::config', :type => :class do
   context 'with version = 1.12 and cloud_provider => aws and cloud_config => undef' do
     let(:params) do
         {
-        'kubernetes_version' => '1.12.2',
+        'kubernetes_version' => '1.12.3',
         'node_name' => 'foo',
         'cloud_provider' => 'aws',
-        'cloud_config' => '',
+        'cloud_config' => :undef,
         'kubelet_extra_arguments' => ['foo: bar'],
         }
     end
 
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
        .with_content(/nodeRegistration:\n  name: foo\n  kubeletExtraArgs:\n    foo: bar\n    cloud-provider: aws\n/)
+    }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+       .without_content(%r{apiServerExtraVolumes:\n  - name: cloud\n})
+    }
+  end
+
+  context 'with version = 1.12 and cloud_provider => aws and cloud_config => /etc/kubernetes/cloud.conf' do
+    let(:params) do
+        {
+        'kubernetes_version' => '1.12.3',
+        'node_name' => 'foo',
+        'cloud_provider' => 'aws',
+        'cloud_config' => '/etc/kubernetes/cloud.conf',
+        'kubelet_extra_arguments' => ['foo: bar'],
+        }
+    end
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+       .with_content(%r{apiServerExtraVolumes:\n  - name: cloud\n})
     }
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,6 +51,8 @@ describe 'kubernetes', :type => :class do
     it { should contain_class('kubernetes') }
     it { should contain_class('kubernetes::repos') }
     it { should contain_class('kubernetes::packages')}
+    it { is_expected.to_not contain_class('kubernetes::config')}
+    it { is_expected.to_not contain_class('kubernetes::config::worker')}
     it { should contain_class('kubernetes::service')}
   end
 
@@ -60,7 +62,8 @@ describe 'kubernetes', :type => :class do
       :kubernetes_version => '1.12.2',
     } end
                 
-    it { should_not contain_class('kubernetes::config')}
+    it { is_expected.to_not contain_class('kubernetes::config')}
+    it { is_expected.to contain_class('kubernetes::config::worker')}
   end
 
   context 'with node_label => foo and cloud_provider => undef' do

--- a/spec/defines/kubeadm_init_spec.rb
+++ b/spec/defines/kubeadm_init_spec.rb
@@ -19,14 +19,15 @@ describe 'kubernetes::kubeadm_init', :type => :define do
   end
 
   context 'with apiserver_advertise_address => 10.0.0.1' do
-  let(:params) { {
-                  'apiserver_advertise_address' => '10.0.0.1',
-                  'node_name' => 'kube-master',
-                  'path' => [ '/bin','/usr/bin','/sbin'],
-                  'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
-
-               } }
-   it { should compile.with_all_deps }  
-   it { should contain_exec('kubeadm init').with_command("kubeadm init --apiserver-advertise-address '10.0.0.1' --node-name 'kube-master'")}
+    let(:params) do
+      {
+        'config' => '/etc/kubernetes/config.yaml',
+        'node_name' => 'kube-master',
+        'path' => [ '/bin','/usr/bin','/sbin'],
+        'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+      }
+    end
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm init').with_command("kubeadm init --config '/etc/kubernetes/config.yaml'")}
   end
 end

--- a/spec/defines/kubeadm_join_spec.rb
+++ b/spec/defines/kubeadm_join_spec.rb
@@ -18,18 +18,35 @@ describe 'kubernetes::kubeadm_join', :type => :define do
     }
   end
 
- context 'with controller_address => 10.0.0.1:6443' do
-  let(:params) { {
-                  'controller_address' => '10.0.0.1:6443',
-                  'node_name' => 'kube-node',
-                  'path' => [ '/bin','/usr/bin','/sbin'],
-                  'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
-                  'token' => 'token',
-                  'ca_cert_hash' => 'hash',
-                  
-               } }
+  let(:params) do
+    {
+      'config' => '/etc/kubernetes/config.yaml',
+      'controller_address' => '10.0.0.1:6443',
+      'node_name' => 'kube-node',
+      'path' => [ '/bin','/usr/bin','/sbin'],
+      'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+      'discovery_token' => 'token',
+      'token' => 'token',
+      'tls_bootstrap_token' => 'token',
+      'ca_cert_hash' => 'hash',
+    }
+  end
 
-      it { should compile.with_all_deps }
-      it { should contain_exec('kubeadm join').with_command("kubeadm join '10.0.0.1:6443' --discovery-token-ca-cert-hash 'sha256:hash' --node-name 'kube-node' --token 'token'")}
+  context 'with kubernetes_version => 1.10.2 and controller_address => 10.0.0.1:6443' do
+    let(:params) do
+      super().merge({'kubernetes_version' => '1.10.2'})
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm join').with_command("kubeadm join '10.0.0.1:6443' --config '/etc/kubernetes/config.yaml' --discovery-token 'token' --discovery-token-ca-cert-hash 'sha256:hash' --node-name 'kube-node' --token 'token'")}
+  end
+
+  context 'with kubernetes_version => 1.12.3 and controller_address => 10.0.0.1:6443' do
+    let(:params) do
+      super().merge({:kubernetes_version => '1.12.3'})
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm join').with_command("kubeadm join --config '/etc/kubernetes/config.yaml'")}
   end
 end

--- a/templates/config-alpha3.yaml.erb
+++ b/templates/config-alpha3.yaml.erb
@@ -48,10 +48,26 @@ apiServerExtraArgs:
   <%= arg %>
   <%- end -%>
 <%- end -%>
+<%- if @apiserver_extra_volumes -%>
+apiServerExtraVolumes:
+  <%- @apiserver_extra_volumes.each do |name, config| -%>
+  - name: <%= name %>
+    hostPath: <%= config['hostPath'] %>
+    mountPath: <%= config['mountPath'] %>
+  <%- end -%>
+<%- end -%>
 <%- if @controllermanager_merged_extra_arguments -%>
 controllerManagerExtraArgs:
   <%- @controllermanager_merged_extra_arguments.each do |arg| -%>
   <%= arg %>
+  <%- end -%>
+<%- end -%>
+<%- if @controllermanager_extra_volumes -%>
+controllerManagerExtraVolumes:
+  <%- @controllermanager_extra_volumes.each do |name, config| -%>
+  - name: <%= name %>
+    hostPath: <%= config['hostPath'] %>
+    mountPath: <%= config['mountPath'] %>
   <%- end -%>
 <%- end -%>
 <% if @apiserver_cert_extra_sans -%>

--- a/templates/v1alpha3/config_worker.yaml.erb
+++ b/templates/v1alpha3/config_worker.yaml.erb
@@ -1,0 +1,28 @@
+apiVersion: kubeadm.k8s.io/v1alpha3
+caCertPath: /etc/kubernetes/pki/ca.crt
+kind: JoinConfiguration
+discoveryToken: <%= @discovery_token %>
+discoveryTokenAPIServers:
+  - '<%= @controller_address %>'
+<% if @discovery_token_hash -%>
+discoveryTokenCACertHashes: 
+  - 'sha256:<%= @discovery_token_hash %>'
+discoveryTokenUnsafeSkipCAVerification: <%= @skip_ca_verification %>
+<% else -%>
+discoveryTokenUnsafeSkipCAVerification: true
+<% end -%>
+discoveryTimeout: 5m0s
+featureGates: <%= @feature_gates %>
+tlsBootstrapToken: <%= @tls_bootstrap_token %>
+token: <%= @token %>
+nodeRegistration:
+  name: <%= @node_name %>
+  <%- if @container_runtime == "cri_containerd" -%>
+  criSocket: /run/containerd/containerd.sock
+  <%- end -%>
+  <%- if @kubelet_merged_extra_arguments -%>
+  kubeletExtraArgs:
+    <%- @kubelet_merged_extra_arguments.each do |arg| -%>
+    <%= arg %>
+    <%- end -%>
+  <%- end -%>


### PR DESCRIPTION
This resolves the same cloud_provider problem for workers as the previous patch.
It also does some strategic structure for the new config-file-oriented world,
which will hopefully make it easier to obsolete older versions with less pain.

I wouldn't merge this yet, I don't think it's been tested all the ways it needs to be. We need some eyeballs on this in different environments.