### PR TITLE
Fix cni network provider

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -29,7 +29,7 @@ class kubernetes::kube_addons (
   exec { 'Install cni network provider':
     command => "kubectl apply -f ${cni_network_provider}",
     onlyif  => 'kubectl get nodes',
-    creates => '/etc/cni/net.d'
+    unless  => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node)'"
     }
 
   if $schedule_on_controller {


### PR DESCRIPTION
If a user deletes the flannel or the weave daemonset, a re-puppet should
add flannel back to the cluster. Because of the creates statement, one
would have to `rm -rf /etc/cni/net.d` and then re-puppet to get flannel
back. This is not intuitive behavor. This patch will re-apply flannel if
no flannel or weave daemonset exists.