### PR TITLE
Dashboard no longer has deploy YAML on master branch

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,6 +186,10 @@
 #   This is a bool that determines if the kubernetes dashboard is installed.
 #   Defaults to false
 #
+# [*dashboard_version*]
+#   The version of Kubernetes dashboard you want to install.
+#   Defaults to v1.10.1
+#
 # [*schedule_on_controller*]
 #   A flag to remove the master role and allow pod scheduling on controllers
 #   Defaults to true
@@ -337,6 +341,7 @@ class kubernetes (
   Optional[String] $cni_network_provider       = undef,
   Optional[String] $cni_rbac_binding           = undef,
   Boolean $install_dashboard                   = false,
+  String $dashboard_version                    = 'v1.10.1',
   Boolean $schedule_on_controller              = false,
   Integer $api_server_count                    = undef,
   String $kubernetes_ca_crt                    = undef,

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -4,6 +4,7 @@ class kubernetes::kube_addons (
   Optional[String] $cni_network_provider     = $kubernetes::cni_network_provider,
   Optional[String] $cni_rbac_binding         = $kubernetes::cni_rbac_binding,
   Boolean $install_dashboard                 = $kubernetes::install_dashboard,
+  String $dashboard_version                  = $kubernetes::dashboard_version,
   String $kubernetes_version                 = $kubernetes::kubernetes_version,
   Boolean $controller                        = $kubernetes::controller,
   Optional[Boolean] $schedule_on_controller  = $kubernetes::schedule_on_controller,
@@ -42,7 +43,7 @@ class kubernetes::kube_addons (
 
   if $install_dashboard  {
     exec { 'Install Kubernetes dashboard':
-      command => 'kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml',
+      command => "kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${dashboard_version}/src/deploy/recommended/kubernetes-dashboard.yaml",
       onlyif  => 'kubectl get nodes',
       unless  => 'kubectl -n kube-system get pods | grep kubernetes-dashboard',
       }

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -20,6 +20,7 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_rbac_binding' => 'foo',
       'cni_network_provider' => 'https://foo.test',
       'install_dashboard' => false,
+      'dashboard_version' => 'v1.10.1',
       'kubernetes_version' => '1.10.2',
       'schedule_on_controller' => true,
       'node_name' => 'foo',
@@ -31,6 +32,21 @@ describe 'kubernetes::kube_addons', :type => :class do
     it { should contain_exec('schedule on controller')}
   end
 
+  context 'with install_dashboard => false' do
+    let(:params) do {
+      'controller' => true,
+      'cni_rbac_binding' => nil,
+      'cni_network_provider' => 'https://foo.test',
+      'install_dashboard' => false,
+      'kubernetes_version' => '1.10.2',
+      'dashboard_version' => 'v1.10.1',
+      'schedule_on_controller' => false,
+      'node_name' => 'foo',
+      }
+    end
+    it { is_expected.to_not contain_exec('Install Kubernetes dashboard')}
+  end
+
   context 'with install_dashboard => true' do
     let(:params) do {
       'controller' => true,
@@ -38,10 +54,11 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_network_provider' => 'https://foo.test',
       'install_dashboard' => true,
       'kubernetes_version' => '1.10.2',
+      'dashboard_version' => 'v1.10.1',
       'schedule_on_controller' => false,
       'node_name' => 'foo',
       }
     end
-    it { should contain_exec('Install Kubernetes dashboard')}
+    it { is_expected.to contain_exec('Install Kubernetes dashboard').with_command(%r{dashboard/v1.10.1/src}) }
   end
 end


### PR DESCRIPTION
It appears they want people to install from specific branches rather than master. I can't imagine why ;-)

This adds a dashboard version parameter which is the branch name to use, so one can select an alternative branch if they want. Tests were updated too.