### PR TITLE
Fix systemd cpu/memory problems on RedHat

### DIFF
--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -78,6 +78,14 @@ describe 'kubernetes::service', :type => :class do
     it { should contain_service('kubelet')}
   end
 
+  context 'with os.family => RedHat' do
+    let(:facts) do
+      super().merge({ :os => { :family => 'RedHat' }})
+    end
+
+    it { is_expected.to contain_file('/etc/systemd/system/kubelet.service.d/11-cgroups.conf') }
+  end
+
   context 'with version => 1.10 and cloud_provider => aws and cloud_config => undef' do
     let(:params) do
         {


### PR DESCRIPTION
This solves the following problems on RedHat:
```
Dec 5 12:42:03 kubelet: E1205 12:42:03.527763 23059 summary.go:92] Failed to get system container stats for "/system.slice/kubelet.service": failed to get cgroup stats for "/system.slice/kubelet.service": failed to get container info for "/system.slice/kubelet.service": unknown container "/system.slice/kubelet.service"
Dec 5 12:42:03 kubelet: E1205 12:42:03.527796 23059 summary.go:92] Failed to get system container stats for "/system.slice/docker.service": failed to get cgroup stats for "/system.slice/docker.service": failed to get container info for "/system.slice/docker.service": unknown container "/system.slice/docker.service"
Dec 5 12:42:03 kubelet: W1205 12:42:03.527852 23059 helpers.go:847] eviction manager: no observation found for eviction signal allocatableNodeFs.available
```

The fix is well known, but for some reason hasn't been added to the kubelet package:

- https://github.com/kubernetes/kubernetes/issues/26198
- https://github.com/kubernetes/kubernetes/issues/56850
- https://github.com/kubernetes/kops/issues/4049#issuecomment-399030872

All kubernetes package installations have added this change to resolve the problem:

- https://github.com/openshift/origin/pull/8989#issuecomment-223502879
- https://github.com/kontena/pharos-cluster/issues/440#issuecomment-399022473
- https://github.com/kubernetes/kops/commit/248f08b467d20353394ee16a9f27b10174267158
- http://kb.cloudblue.com/en/133102

I can't fathom why this isn't part of the kubelet package, but it seems kubernetes has pushed this out to the distribution to solve and since Puppet is providing the implementation we have to do it.