### PR TITLE
Quote the URL or path passed applying network addon config.

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -28,7 +28,7 @@ class kubernetes::kube_addons (
   }
 
   exec { 'Install cni network provider':
-    command => "kubectl apply -f ${cni_network_provider}",
+    command => "kubectl apply -f \"${cni_network_provider}\"",
     onlyif  => 'kubectl get nodes',
     unless  => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node)'"
     }


### PR DESCRIPTION
For weave, one can set additional options by adding to the URL
query string:
  https://github.com/weaveworks/weave/blob/master/site/kubernetes/kube-addon.md#using-cloudweaveworks
However, when unquoted, the additional '&' is interpreted
specially by the shell.