### PR TITLE
Honor overridden service address range in alpha3 config.

### DIFF
--- a/templates/config-alpha3.yaml.erb
+++ b/templates/config-alpha3.yaml.erb
@@ -42,6 +42,7 @@ kind: ClusterConfiguration
 kubernetesVersion: v<%= @kubernetes_version %>
 networking:
   podSubnet: <%= @cni_pod_cidr %>
+  serviceSubnet: <%= @service_cidr %>
 <%- if @apiserver_merged_extra_arguments -%>
 apiServerExtraArgs:
   <%- @apiserver_merged_extra_arguments.each do |arg| -%>


### PR DESCRIPTION
This was in the alpha1 config, but it is missing in the alpha3 config.