### PR TITLE
Use fact method to more gracefully handle missing facts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -403,7 +403,7 @@ class kubernetes (
         }
       }
     }
-    default: { $node_name = pick($node_label, $facts['networking']['hostname']) }
+    default: { $node_name = pick($node_label, fact('networking.hostname')) }
   }
 
   if $controller {

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -24,10 +24,11 @@ class kubernetes::repos (
   if $create_repos {
     case $facts['os']['family']  {
       'Debian': {
+        $codename = fact('os.distro.codename')
         apt::source { 'kubernetes':
           location => pick($kubernetes_apt_location,'http://apt.kubernetes.io'),
           repos    => pick($kubernetes_apt_repos,'main'),
-          release  => pick($kubernetes_apt_release,"kubernetes-${facts['os']['distro']['codename']}"),
+          release  => pick($kubernetes_apt_release,"kubernetes-${codename}"),
           key      => {
             'id'     => pick($kubernetes_key_id,'54A647F9048D5688D7DA2ABE6A030B21BA07F4FB'),
             'source' => pick($kubernetes_key_source,'https://packages.cloud.google.com/apt/doc/apt-key.gpg'),
@@ -38,7 +39,7 @@ class kubernetes::repos (
             apt::source { 'docker':
               location => pick($docker_apt_location,'https://apt.dockerproject.org/repo'),
               repos    => pick($docker_apt_repos,'main'),
-              release  => pick($docker_apt_release,"ubuntu-${facts['os']['distro']['codename']}"),
+              release  => pick($docker_apt_release,"ubuntu-${codename}"),
               key      => {
                 'id'     => pick($docker_key_id,'58118E89F3A912897C070ADBF76221572C52609D'),
                 'source' => pick($docker_key_source,'https://apt.dockerproject.org/gpg'),


### PR DESCRIPTION
Without this, a puppet4 agent which doesn't appear to have newer facts will fail with the
error "Evaluation Error: Operator '[]' is not applicable to an Undef Value".  After this change, evaluation works and the override values supplied to the model can take effect.