### PR TITLE
Fix alpha3 template

### DIFF
--- a/templates/config-alpha3.yaml.erb
+++ b/templates/config-alpha3.yaml.erb
@@ -37,7 +37,6 @@ etcd:
         certFile: /etc/kubernetes/pki/etcd/client.crt
         keyFile: /etc/kubernetes/pki/etcd/client.key
 imageRepository: <%= @image_repository %>
-nodeName: <%= @node_name %>
 kind: ClusterConfiguration
 kubernetesVersion: v<%= @kubernetes_version %>
 networking:


### PR DESCRIPTION
nodeName isn't valid in v1alpha3 cluster configuration https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3#ClusterConfiguration

This patch removes the JSON formatting error.
