### PR TITLE
Mount cloud configuration on ApiServer and ControllerManager pods

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -85,9 +85,23 @@ class kubernetes::config (
     $apiserver_merged_extra_arguments = concat($apiserver_extra_arguments, $cloud_args)
     $kubelet_merged_extra_arguments = concat($kubelet_extra_arguments, $cloud_args)
     $controllermanager_merged_extra_arguments = $cloud_args
+
+    # could check against Kubernetes 1.10 here, but that uses alpha1 config which doesn't have these options
+    if $cloud_config {
+      # The cloud config must be mounted into the apiserver and controllermanager containers
+      $controllermanager_extra_volumes = $apiserver_extra_volumes = {
+        'cloud' => {
+          hostPath  => $cloud_config,
+          mountPath => $cloud_config,
+        }
+      }
+    }
   }
   else {
+    $apiserver_merged_extra_arguments = $apiserver_extra_arguments
+    $apiserver_extra_volumes = {}
     $controllermanager_merged_extra_arguments = []
+    $controllermanager_extra_volumes = {}
   }
 
   # to_yaml emits a complete YAML document, so we must remove the leading '---'

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -62,7 +62,6 @@ describe 'kubernetes::config', :type => :class do
     let(:params) do 
         {
         'manage_etcd' => false,
-        'cloud_config' => '',
         'kubeadm_extra_config' => {'foo' => ['bar', 'baz']},
         'kubelet_extra_config' => {'baz' => ['bar', 'foo']},
         'kubelet_extra_arguments' => ['foo'],
@@ -95,16 +94,35 @@ describe 'kubernetes::config', :type => :class do
   context 'with version = 1.12 and cloud_provider => aws and cloud_config => undef' do
     let(:params) do
         {
-        'kubernetes_version' => '1.12.2',
+        'kubernetes_version' => '1.12.3',
         'node_name' => 'foo',
         'cloud_provider' => 'aws',
-        'cloud_config' => '',
+        'cloud_config' => :undef,
         'kubelet_extra_arguments' => ['foo: bar'],
         }
     end
 
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
        .with_content(/nodeRegistration:\n  name: foo\n  kubeletExtraArgs:\n    foo: bar\n    cloud-provider: aws\n/)
+    }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+       .without_content(%r{apiServerExtraVolumes:\n  - name: cloud\n})
+    }
+  end
+
+  context 'with version = 1.12 and cloud_provider => aws and cloud_config => /etc/kubernetes/cloud.conf' do
+    let(:params) do
+        {
+        'kubernetes_version' => '1.12.3',
+        'node_name' => 'foo',
+        'cloud_provider' => 'aws',
+        'cloud_config' => '/etc/kubernetes/cloud.conf',
+        'kubelet_extra_arguments' => ['foo: bar'],
+        }
+    end
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+       .with_content(%r{apiServerExtraVolumes:\n  - name: cloud\n})
     }
   end
 end

--- a/templates/config-alpha3.yaml.erb
+++ b/templates/config-alpha3.yaml.erb
@@ -48,10 +48,26 @@ apiServerExtraArgs:
   <%= arg %>
   <%- end -%>
 <%- end -%>
+<%- if @apiserver_extra_volumes -%>
+apiServerExtraVolumes:
+  <%- @apiserver_extra_volumes.each do |name, config| -%>
+  - name: <%= name %>
+    hostPath: <%= config['hostPath'] %>
+    mountPath: <%= config['mountPath'] %>
+  <%- end -%>
+<%- end -%>
 <%- if @controllermanager_merged_extra_arguments -%>
 controllerManagerExtraArgs:
   <%- @controllermanager_merged_extra_arguments.each do |arg| -%>
   <%= arg %>
+  <%- end -%>
+<%- end -%>
+<%- if @controllermanager_extra_volumes -%>
+controllerManagerExtraVolumes:
+  <%- @controllermanager_extra_volumes.each do |name, config| -%>
+  - name: <%= name %>
+    hostPath: <%= config['hostPath'] %>
+    mountPath: <%= config['mountPath'] %>
   <%- end -%>
 <%- end -%>
 <% if @apiserver_cert_extra_sans -%>


### PR DESCRIPTION
If a cloud configuration is used, it must be mounted in these pods as of 1.11
  https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#new-deprecations

Failure to do so causes these two pods to startFail and the cluster never comes up.
    https://github.com/kubernetes/kubernetes/issues/57718
