### PR TITLE
Remove dependency on puppet-wget (use puppet-archive instead)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@ fixtures:
   forge_modules:
     stdlib: 'puppetlabs-stdlib'
     apt: 'puppetlabs-apt'
-    wget: 'puppet-wget'
     archive: "puppet-archive"
     translate: "puppetlabs-translate"
     augeasproviders_sysctl: "herculesteam-augeasproviders_sysctl"

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -83,16 +83,13 @@ class kubernetes::packages (
 
   elsif $container_runtime == 'cri_containerd' {
 
-    wget::fetch { 'download runc binary':
-      source      => $runc_source,
-      destination => '/usr/bin/runc',
-      timeout     => 0,
-      verbose     => false,
-      unless      => "test $(ls -A /usr/bin/runc 2>/dev/null)",
-      before      => File['/usr/bin/runc'],
+    archive { '/usr/bin/runc':
+      source  => $runc_source,
+      extract => false,
+      cleanup => false,
+      creates => '/usr/bin/runc',
     }
-
-    file {'/usr/bin/runc':
+    -> file { '/usr/bin/runc':
       mode => '0700'
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -21,10 +21,6 @@
       "version_requirement": ">= 2.0.0 < 3.1.0"
     },
     {
-      "name": "puppet-wget",
-      "version_requirement": "2.0.0"
-    },
-    {
       "name": "puppetlabs-translate",
       "version_requirement": ">= 0.0.1 < 1.1.0"
     },

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -25,7 +25,7 @@ describe 'kubernetes::packages', :type => :class do
         'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
-        'docker_package_name' => 'docker-engine',   
+        'docker_package_name' => 'docker-engine',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -47,7 +47,6 @@ describe 'kubernetes::packages', :type => :class do
     let(:facts) do
       {
         :osfamily         => 'Debian', #needed to run dependent tests from fixtures camptocamp-kmod
-        :operatingsystem  => 'Ubuntu', #needed to run dependent tests from fixtures puppet-wget
         :kernel           => 'Linux',
         :os               => {
           :family => "Debian",
@@ -71,8 +70,8 @@ describe 'kubernetes::packages', :type => :class do
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
         'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
         'runc_source' => 'https://github.com/runcsource',
-        'controller' => true, 
-        'docker_package_name' => 'docker-engine',  
+        'controller' => true,
+        'docker_package_name' => 'docker-engine',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => false,
@@ -83,16 +82,16 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
-    it { should contain_wget__fetch("download runc binary")}
+    it { should contain_archive('/usr/bin/runc')}
     it { should contain_file('/usr/bin/runc')}
     it { should contain_archive('containerd-1.1.0.linux-amd64.tar.gz')}
     it { should_not contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
     it { should contain_package('kubelet').with_ensure('1.10.2-00')}
     it { should contain_package('kubectl').with_ensure('1.10.2-00')}
     it { should contain_package('kubeadm').with_ensure('1.10.2-00')}
-    
+
   end
-  
+
   context 'with osfamily => Debian and container_runtime => Docker and manage_docker => false and manage_etcd => true' do
     let(:facts) do
       {
@@ -121,7 +120,7 @@ describe 'kubernetes::packages', :type => :class do
         'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
-        'docker_package_name' => 'docker-engine',   
+        'docker_package_name' => 'docker-engine',
         'disable_swap' => true,
         'manage_docker' => false,
         'manage_etcd' => true,
@@ -143,7 +142,6 @@ describe 'kubernetes::packages', :type => :class do
     let(:facts) do
       {
         :osfamily         => 'Debian', #needed to run dependent tests from fixtures camptocamp-kmod
-        :operatingsystem  => 'Ubuntu', #needed to run dependent tests from fixtures puppet-wget
         :kernel           => 'Linux',
         :os               => {
           :family => "Debian",
@@ -167,8 +165,8 @@ describe 'kubernetes::packages', :type => :class do
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
         'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
         'runc_source' => 'https://github.com/runcsource',
-        'controller' => true, 
-        'docker_package_name' => 'docker-engine',  
+        'controller' => true,
+        'docker_package_name' => 'docker-engine',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -179,6 +177,6 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
-    it { should contain_exec('disable swap')}  
-  end    
+    it { should contain_exec('disable swap')}
+  end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -43,7 +43,6 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'stahnma-epel'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-translate', '--version', '1.0.0' ), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppet-archive'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppet-wget'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'herculesteam-augeasproviders_sysctl'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'herculesteam-augeasproviders_core'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'camptocamp-kmod'), { :acceptable_exit_codes => [0,1] }


### PR DESCRIPTION
The `wget` module is unnecessary as the more widely-used `archive` module can download files without extracting archives.