### PR TITLE
Allow setting etcd initial cluster state

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ A Hiera example is `kubernetes::etcd_initial_cluster: kube-master:172.17.10.101,
 
 Defaults to `undef`.
 
+#### `etcd_initial_cluster_state`
+
+Informs etcd on the state of the cluster when starting. Useful for adding single nodes to a cluster. Allowed values are `new` or `existing`.
+
+Defaults to `new`
+
 #### `etcd_peers`
 
 Specifies how etcd lists the peers to connect to the cluster.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class kubernetes::config (
   String $cni_pod_cidr = $kubernetes::cni_pod_cidr,
   String $kube_api_advertise_address = $kubernetes::kube_api_advertise_address,
   String $etcd_initial_cluster = $kubernetes::etcd_initial_cluster,
+  String $etcd_initial_cluster_state = $kubernetes::etcd_initial_cluster_state,
   Integer $api_server_count = $kubernetes::api_server_count,
   String $etcd_version = $kubernetes::etcd_version,
   String $token = $kubernetes::token,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,11 @@
 #   An example with hiera would be kubernetes::etcd_initial_cluster: etcd-kube-master=http://172.17.10.101:2380,etcd-kube-replica-master-01=http://172.17.10.210:2380,etcd-kube-replica-master-02=http://172.17.10.220:2380
 #   Defaults to undef
 #
+# [*etcd_initial_cluster_state*]
+#     This will tell etcd the initial state of the cluster. Useful for adding a node to the cluster. Allowed values are
+#   "new" or "existing"
+#   Defaults to "new"
+#
 # [*etcd_ca_key*]
 #   This is the ca certificate key data for the etcd cluster. This must be passed as string not as a file.
 #   Defaults to undef
@@ -330,6 +335,8 @@ class kubernetes (
   Optional[String] $etcd_ip                    = undef,
   Optional[Array] $etcd_peers                  = undef,
   Optional[String] $etcd_initial_cluster       = undef,
+  Optional[Enum['new','existing']]
+                   $etcd_initial_cluster_state = 'new',
   String $etcd_ca_key                          = undef,
   String $etcd_ca_crt                          = undef,
   String $etcdclient_key                       = undef,

--- a/templates/etcd/etcd.service.erb
+++ b/templates/etcd/etcd.service.erb
@@ -27,7 +27,7 @@ ExecStart=/usr/local/bin/etcd --name <%= @hostname %> \
     --peer-trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt \
     --initial-cluster <%= @etcd_initial_cluster %> \
     --initial-cluster-token my-etcd-token \
-    --initial-cluster-state new
+    --initial-cluster-state <%= @etcd_initial_cluster_state %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is to allow setting the initial cluster state. I've made a guess on what formatting ya'll would want. Since there weren't already tests on the _content_ of the etcd systemd service file I didn't create a bunch of new ones but I don't have a problem if ya'll want it.

I've also created this issue that matches the pull request #245