### PR TITLE
Workaround race condition on default sa creation

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -7,7 +7,6 @@ class kubernetes::cluster_roles (
   String $container_runtime = $kubernetes::container_runtime,
   Optional[Array] $ignore_preflight_errors = []
 ) {
-  $path = ['/usr/bin','/bin','/sbin','/usr/local/bin']
   $env_controller = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf']
   #Worker nodes do not have admin.conf present
   $env_worker = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf']
@@ -23,7 +22,6 @@ class kubernetes::cluster_roles (
 
   if $controller {
     kubernetes::kubeadm_init { $node_name:
-      path                    => $path,
       env                     => $env_controller,
       ignore_preflight_errors => $preflight_errors,
       }
@@ -31,7 +29,6 @@ class kubernetes::cluster_roles (
 
   if $worker {
     kubernetes::kubeadm_join { $node_name:
-      path                    => $path,
       env                     => $env_worker,
       cri_socket              => $cri_socket,
       ignore_preflight_errors => $preflight_errors,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -313,6 +313,10 @@
 #  A flag to manage required sysctl settings.
 #  Defaults to true
 #
+# [*default_path*]
+#  The path to be used when running kube* commands
+#  Defaults to ['/usr/bin','/bin','/sbin','/usr/local/bin']
+#
 # Authors
 # -------
 #
@@ -403,6 +407,7 @@ class kubernetes (
   Boolean $manage_sysctl_settings              = true,
   Boolean $create_repos                        = true,
   String $image_repository                     = 'k8s.gcr.io',
+  Array[String] $default_path                  = ['/usr/bin','/bin','/sbin','/usr/local/bin'],
 ){
   if ! $facts['os']['family'] in ['Debian','RedHat'] {
     notify {"The OS family ${facts['os']['family']} is not supported by this module":}

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -9,10 +9,11 @@ class kubernetes::kube_addons (
   Boolean $controller                        = $kubernetes::controller,
   Optional[Boolean] $schedule_on_controller  = $kubernetes::schedule_on_controller,
   String $node_name                          = $kubernetes::node_name,
+  Array $path                                = $kubernetes::default_path,
 ){
 
   Exec {
-    path        => ['/usr/bin', '/bin'],
+    path        => $path,
     environment => [ 'HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
     logoutput   => true,
     tries       => 10,

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -3,8 +3,8 @@ define kubernetes::kubeadm_init (
   String $node_name                             = $kubernetes::node_name,
   Optional[String] $config                      = $kubernetes::config_file,
   Boolean $dry_run                              = false,
+  Array $path                                   = $kubernetes::default_path,
   Optional[Array] $env                          = undef,
-  Optional[Array] $path                         = undef,
   Optional[Array] $ignore_preflight_errors      = undef,
 ) {
   $kubeadm_init_flags = kubeadm_init_flags({
@@ -25,4 +25,6 @@ define kubernetes::kubeadm_init (
     unless      => $unless_init,
   }
 
+  # This prevents a known race condition https://github.com/kubernetes/kubernetes/issues/66689
+  kubernetes::wait_for_default_sa { 'default': }
 }

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -13,7 +13,7 @@ define kubernetes::kubeadm_join (
   Optional[String] $discovery_file         = undef,
   Optional[Array] $env                     = undef,
   Optional[Array] $ignore_preflight_errors = undef,
-  Optional[Array] $path                    = undef,
+  Array $path                              = $kubernetes::default_path,
   Boolean $skip_ca_verification            = false,
 ) {
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -20,7 +20,6 @@ class kubernetes::packages (
   Boolean $disable_swap                        = $kubernetes::disable_swap,
   Boolean $manage_kernel_modules               = $kubernetes::manage_kernel_modules,
   Boolean $manage_sysctl_settings              = $kubernetes::manage_sysctl_settings,
-
 ) {
 
   $kube_packages = ['kubelet', 'kubectl', 'kubeadm']

--- a/manifests/wait_for_default_sa.pp
+++ b/manifests/wait_for_default_sa.pp
@@ -1,0 +1,19 @@
+# == kubernetes::wait_for_default_sa
+define kubernetes::wait_for_default_sa (
+  String $namespace            = $title,
+  Array $path                  = $kubernetes::default_path,
+  Optional[Integer] $timeout   = undef,
+  Optional[Integer] $tries     = 5,
+  Optional[Integer] $try_sleep = 6,
+) {
+  $safe_namespace = shell_escape($namespace)
+
+  # This prevents a known race condition https://github.com/kubernetes/kubernetes/issues/66689
+  exec { "wait for default serviceaccount creation in ${safe_namespace}":
+    command   => "kubectl -n ${safe_namespace} get serviceaccount default -o name",
+    path      => $path,
+    timeout   => $timeout,
+    tries     => $tries,
+    try_sleep => $try_sleep,
+  }
+}

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe 'kubernetes::kube_addons', :type => :class do
+  let(:pre_condition) { 'include kubernetes' }
   let(:facts) do
     {
       :os               => {

--- a/spec/defines/kubeadm_init_spec.rb
+++ b/spec/defines/kubeadm_init_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'kubernetes::kubeadm_init', :type => :define do
+  let(:pre_condition) { 'include kubernetes' }
   let(:title) { 'kubeadm init' }
   let(:facts) do
     {
@@ -29,5 +30,6 @@ describe 'kubernetes::kubeadm_init', :type => :define do
     end
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_exec('kubeadm init').with_command("kubeadm init --config '/etc/kubernetes/config.yaml'")}
+    it { is_expected.to contain_kubernetes__wait_for_default_sa('default')}
   end
 end

--- a/spec/defines/kubeadm_join_spec.rb
+++ b/spec/defines/kubeadm_join_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'kubernetes::kubeadm_join', :type => :define do
+  let(:pre_condition) { 'include kubernetes' }
   let(:title) { 'kubeadm join' }
   let(:facts) do
     {

--- a/spec/defines/wait_for_default_sa_spec.rb
+++ b/spec/defines/wait_for_default_sa_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'kubernetes::wait_for_default_sa', :type => :define do
+  let(:pre_condition) { 'include kubernetes' }
+  let(:title) { 'default' }
+  let(:facts) do
+    {
+      :kernel           => 'Linux',
+      :os               => {
+        :family => "Debian",
+        :name    => 'Ubuntu',
+        :release => {
+          :full => '16.04',
+        },
+        :distro => {
+          :codename => "xenial",
+        },
+      },
+    }
+  end
+
+  context 'with namespace default and no options' do
+    let(:params) do
+      {
+        'namespace' => 'default',
+      }
+    end
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('wait for default serviceaccount creation in default')
+          .with_command('kubectl -n default get serviceaccount default -o name')}
+  end
+
+  context 'with namespace foo and path /bar' do
+    let(:params) do
+      {
+        'namespace' => 'foo',
+        'path'      => ['/bar'],
+      }
+    end
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('wait for default serviceaccount creation in foo')
+          .with_command('kubectl -n foo get serviceaccount default -o name')
+          .with_path(['/bar'])}
+  end
+end


### PR DESCRIPTION
This is a workaround for a known race condition where you can try to add a Pod before the cluster has created the default serviceaccount https://github.com/kubernetes/kubernetes/issues/66689
```
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_init[kube-master]/Exec[kubeadm init]/returns: executed successfully
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: serviceaccount/weave-net created
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: clusterrole.rbac.authorization.k8s.io/weave-net created
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: clusterrolebinding.rbac.authorization.k8s.io/weave-net created
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: role.rbac.authorization.k8s.io/weave-net created
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: rolebinding.rbac.authorization.k8s.io/weave-net created
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: daemonset.extensions/weave-net created
Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network provider]/returns: executed successfully
Notice: /Stage[main]/Profile::Kubectl::Templates/Exec[kubectl_template_busybox]/returns: Error from server (Forbidden): error when creating "/k8s/templates/busybox.yaml": pods "busybox" is forbidden: error looking up service account default/default: serviceaccount "default" not found
Error: 'kubectl apply -f /k8s/templates/busybox.yaml' returned 1 instead of one of [0]
Error: /Stage[main]/Profile::Kubectl::Templates/Exec[kubectl_template_busybox]/returns: change from 'notrun' to ['0'] failed: 'kubectl apply -f /k8s/templates/busybox.yaml' returned 1 instead of one of [0]
```

This adds a test for the SA, which will trigger the accounting query to speed up its creation.
