### PR TITLE
Safe command lines for CNI network installs

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -1,7 +1,7 @@
 # Class kubernetes kube_addons
 class kubernetes::kube_addons (
 
-  Optional[String] $cni_network_provider     = $kubernetes::cni_network_provider,
+  String $cni_network_provider               = $kubernetes::cni_network_provider,
   Optional[String] $cni_rbac_binding         = $kubernetes::cni_rbac_binding,
   Boolean $install_dashboard                 = $kubernetes::install_dashboard,
   String $dashboard_version                  = $kubernetes::dashboard_version,
@@ -20,15 +20,17 @@ class kubernetes::kube_addons (
     }
 
   if $cni_rbac_binding {
+    $shellsafe_binding = shell_escape($cni_rbac_binding)
     exec { 'Install calico rbac bindings':
-    command => "kubectl apply -f ${cni_rbac_binding}",
+    command => "kubectl apply -f ${shellsafe_binding}",
     onlyif  => 'kubectl get nodes',
     unless  => 'kubectl get clusterrole | grep calico'
     }
   }
 
+  $shellsafe_provider = shell_escape($cni_network_provider)
   exec { 'Install cni network provider':
-    command => "kubectl apply -f ${cni_network_provider}",
+    command => "kubectl apply -f ${shellsafe_provider}",
     onlyif  => 'kubectl get nodes',
     unless  => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node)'"
     }
@@ -42,8 +44,9 @@ class kubernetes::kube_addons (
   }
 
   if $install_dashboard  {
+    $shellsafe_source = shell_escape("https://raw.githubusercontent.com/kubernetes/dashboard/${dashboard_version}/src/deploy/recommended/kubernetes-dashboard.yaml")
     exec { 'Install Kubernetes dashboard':
-      command => "kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${dashboard_version}/src/deploy/recommended/kubernetes-dashboard.yaml",
+      command => "kubectl apply -f ${shellsafe_source}",
       onlyif  => 'kubectl get nodes',
       unless  => 'kubectl -n kube-system get pods | grep kubernetes-dashboard',
       }

--- a/spec/fixtures/hiera/required_values.yaml
+++ b/spec/fixtures/hiera/required_values.yaml
@@ -23,3 +23,4 @@ kubernetes::controller_address: '172.17.10.101:6443'
 kubernetes::cloud_provider: :undef
 kubernetes::create_repos: true
 kubernetes::disable_swap: true
+kubernetes::cni_network_provider: 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'


### PR DESCRIPTION
I've come around on this, as I've started to experience a lot more need for passing shell metacharacters in the URLs. I believe using stdlib's `shell_escape` is the best, most practical fix.

resolves #232 