### PR TITLE
Store cgroup driver in kubeadm configuration file for kubernetes 1.12+

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -38,6 +38,7 @@ class kubernetes::config::kubeadm (
   Optional[Hash] $kubeadm_extra_config = $kubernetes::kubeadm_extra_config,
   Optional[Hash] $kubelet_extra_config = $kubernetes::kubelet_extra_config,
   String $image_repository = $kubernetes::image_repository,
+  String $cgroup_driver = $kubernetes::cgroup_driver,
 ) {
 
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']
@@ -94,7 +95,6 @@ class kubernetes::config::kubeadm (
       default => ["cloud-provider: ${cloud_provider}", "cloud-config: ${cloud_config}"],
     }
     $apiserver_merged_extra_arguments = concat($apiserver_extra_arguments, $cloud_args)
-    $kubelet_merged_extra_arguments = concat($kubelet_extra_arguments, $cloud_args)
     $controllermanager_merged_extra_arguments = $cloud_args
 
     # could check against Kubernetes 1.10 here, but that uses alpha1 config which doesn't have these options

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -18,19 +18,8 @@ class kubernetes::config::worker (
   Optional[Hash] $kubelet_extra_config     = $kubernetes::kubelet_extra_config,
   Optional[Array] $ignore_preflight_errors = undef,
   Boolean $skip_ca_verification            = false,
+  String $cgroup_driver                    = $kubernetes::cgroup_driver,
 ) {
-  # Need to merge the cloud configuration parameters into extra_arguments
-  if !empty($cloud_provider) {
-    $cloud_args = empty($cloud_config) ? {
-      true    => ["cloud-provider: ${cloud_provider}"],
-      default => ["cloud-provider: ${cloud_provider}", "cloud-config: ${cloud_config}"],
-    }
-    $kubelet_merged_extra_arguments = concat($kubelet_extra_arguments, $cloud_args)
-  }
-  else {
-    $kubelet_merged_extra_arguments = $kubelet_extra_arguments
-  }
-
   # to_yaml emits a complete YAML document, so we must remove the leading '---'
   $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -324,6 +324,10 @@
 #  The path to be used when running kube* commands
 #  Defaults to ['/usr/bin','/bin','/sbin','/usr/local/bin']
 #
+# [*cgroup_driver*]
+#  The cgroup driver to be used.
+#  Defaults to 'systemd' on EL and 'cgroupfs' otherwise
+#
 # Authors
 # -------
 #
@@ -416,6 +420,10 @@ class kubernetes (
   Boolean $create_repos                        = true,
   String $image_repository                     = 'k8s.gcr.io',
   Array[String] $default_path                  = ['/usr/bin','/bin','/sbin','/usr/local/bin'],
+  String $cgroup_driver                        = $facts['os']['family'] ? {
+                                                    'RedHat' => 'systemd',
+                                                    default  => 'cgroupfs',
+                                                  },
 ){
   if ! $facts['os']['family'] in ['Debian','RedHat'] {
     notify {"The OS family ${facts['os']['family']} is not supported by this module":}

--- a/spec/classes/config/worker_spec.rb
+++ b/spec/classes/config/worker_spec.rb
@@ -23,20 +23,30 @@ describe 'kubernetes::config::worker', :type => :class do
     }
   end
 
-  context 'with version => 1.12.3 cloud_provider => undef' do
+  context 'with version => 1.12.3 and node_name => foo and kubelet_extra_args => foo: bar' do
     let(:params) do
       {
         'kubernetes_version' => '1.12.3',
-        'kubelet_extra_arguments' => ['foo'],
+        'node_name' => 'foo',
+        'kubelet_extra_arguments' => ['foo: bar'],
       }
     end
 
+    let(:config_yaml) { YAML.safe_load(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{apiVersion: kubeadm.k8s.io/v1alpha3\n}) }
-    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{  kubeletExtraArgs:\n    foo\n}) }
-    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').without_content(%r{cloud-provider}) }
+    it 'has arg foo in first YAML document (JoinConfig) NodeRegistration' do
+      expect(config_yaml['nodeRegistration']['kubeletExtraArgs']).to include('foo')
+    end
+    it 'has name==foo in first YAML document (JoinConfig) NodeRegistration' do
+      expect(config_yaml['nodeRegistration']).to include('name' => params['node_name'])
+    end
+    it 'does not have cloud-provider in first YAML document (JoinConfig) NodeRegistration' do
+      expect(config_yaml['nodeRegistration']['kubeletExtraArgs']).not_to include('cloud-provider')
+    end
   end
 
-  context 'with version => 1.12.3 cloud_provider => aws' do
+  context 'with version => 1.12.3 and cloud_provider => aws' do
     let(:params) do
       {
         'kubernetes_version' => '1.12.3',
@@ -44,7 +54,14 @@ describe 'kubernetes::config::worker', :type => :class do
       }
     end
 
+    let(:config_yaml) { YAML.safe_load(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{apiVersion: kubeadm.k8s.io/v1alpha3\n}) }
-    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{  kubeletExtraArgs:\n    cloud-provider: aws\n}) }
+    it 'does not have arg foo in first YAML document (JoinConfig) NodeRegistration' do
+      expect(config_yaml['nodeRegistration']['kubeletExtraArgs']).not_to include('foo')
+    end
+    it 'has cloud-provider==aws in first YAML document (JoinConfig) NodeRegistration' do
+      expect(config_yaml['nodeRegistration']['kubeletExtraArgs']).to include('cloud-provider' => 'aws')
+    end
   end
 end

--- a/templates/v1alpha3/config_kubeadm.yaml.erb
+++ b/templates/v1alpha3/config_kubeadm.yaml.erb
@@ -17,12 +17,17 @@ nodeRegistration:
   <%- if @container_runtime == "cri_containerd" -%>
   criSocket: /run/containerd/containerd.sock
   <%- end -%>
-  <%- if @kubelet_merged_extra_arguments -%>
   kubeletExtraArgs:
-    <%- @kubelet_merged_extra_arguments.each do |arg| -%>
+    cgroup-driver: <%= @cgroup_driver %>
+    <%- if @cloud_provider -%>
+    cloud-provider: <%= @cloud_provider %>
+    <%- end -%>
+    <%- if @cloud_config -%>
+    cloud-config: <%= @cloud_config %>
+    <%- end -%>
+    <%- @kubelet_extra_arguments.each do |arg| -%>
     <%= arg %>
     <%- end -%>
-  <%- end -%>
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 CertificatesDir: /etc/kubernetes/pki
@@ -96,12 +101,17 @@ nodeRegistration:
   <%- if @container_runtime == "cri_containerd" -%>
   criSocket: /run/containerd/containerd.sock
   <%- end -%>
-  <%- if @kubelet_merged_extra_arguments -%>
   kubeletExtraArgs:
-    <%- @kubelet_merged_extra_arguments.each do |arg| -%>
+    cgroup-driver: <%= @cgroup_driver %>
+    <%- if @cloud_provider -%>
+    cloud-provider: <%= @cloud_provider %>
+    <%- end -%>
+    <%- if @cloud_config -%>
+    cloud-config: <%= @cloud_config %>
+    <%- end -%>
+    <%- @kubelet_extra_arguments.each do |arg| -%>
     <%= arg %>
     <%- end -%>
-  <%- end -%>
 token: <%= @token %>
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/templates/v1alpha3/config_worker.yaml.erb
+++ b/templates/v1alpha3/config_worker.yaml.erb
@@ -15,7 +15,9 @@ discoveryTokenUnsafeSkipCAVerification: <%= @skip_ca_verification %>
 discoveryTokenUnsafeSkipCAVerification: true
 <% end -%>
 discoveryTimeout: 5m0s
+<% if @feature_gates -%>
 featureGates: <%= @feature_gates %>
+<% end -%>
 tlsBootstrapToken: <%= @tls_bootstrap_token %>
 token: <%= @token %>
 nodeRegistration:
@@ -23,9 +25,14 @@ nodeRegistration:
   <%- if @container_runtime == "cri_containerd" -%>
   criSocket: /run/containerd/containerd.sock
   <%- end -%>
-  <%- if @kubelet_merged_extra_arguments -%>
   kubeletExtraArgs:
-    <%- @kubelet_merged_extra_arguments.each do |arg| -%>
-    <%= arg %>
+    cgroup-driver: <%= @cgroup_driver %>
+    <%- if @cloud_provider -%>
+    cloud-provider: <%= @cloud_provider %>
+    <%- if @cloud_config -%>
+    cloud-config: <%= @cloud_config %>
     <%- end -%>
-  <%- end -%>
+    <%- end -%>
+    <%- @kubelet_extra_arguments.each do |arg| -%>
+    <%= arg %>
+    <%- end %>


### PR DESCRIPTION
```
$  kubelet --help |grep cgroup
      --cgroup-driver string

Driver that the kubelet uses to manipulate cgroups on the host.
Possible values: 'cgroupfs', 'systemd' (default "cgroupfs")
(DEPRECATED: This parameter should be set via the config file specified by the Kubelet's --config flag.
 See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.)
```

This PR also includes major refactoring to make YAML template build tests less prescriptive and less likely to fail due to minor changes that aren't actual failures.