### PR TITLE
Make kubectl environment available in main class

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -7,10 +7,6 @@ class kubernetes::cluster_roles (
   String $container_runtime = $kubernetes::container_runtime,
   Optional[Array] $ignore_preflight_errors = []
 ) {
-  $env_controller = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf']
-  #Worker nodes do not have admin.conf present
-  $env_worker = ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf']
-
   if $container_runtime == 'cri_containerd' {
     $preflight_errors = flatten(['Service-Docker',$ignore_preflight_errors])
     $cri_socket = '/run/containerd/containerd.sock'
@@ -22,14 +18,12 @@ class kubernetes::cluster_roles (
 
   if $controller {
     kubernetes::kubeadm_init { $node_name:
-      env                     => $env_controller,
       ignore_preflight_errors => $preflight_errors,
       }
     }
 
   if $worker {
     kubernetes::kubeadm_join { $node_name:
-      env                     => $env_worker,
       cri_socket              => $cri_socket,
       ignore_preflight_errors => $preflight_errors,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -328,6 +328,10 @@
 #  The cgroup driver to be used.
 #  Defaults to 'systemd' on EL and 'cgroupfs' otherwise
 #
+# [*environment*]
+# The environment passed to kubectl commands.
+# Defaults to setting HOME and KUBECONFIG variables
+#
 # Authors
 # -------
 #
@@ -423,6 +427,10 @@ class kubernetes (
   String $cgroup_driver                        = $facts['os']['family'] ? {
                                                     'RedHat' => 'systemd',
                                                     default  => 'cgroupfs',
+                                                  },
+  Array[String] $environment                   = $controller ? {
+                                                    true    => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+                                                    default => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf'],
                                                   },
 ){
   if ! $facts['os']['family'] in ['Debian','RedHat'] {

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -4,7 +4,7 @@ define kubernetes::kubeadm_init (
   Optional[String] $config                      = $kubernetes::config_file,
   Boolean $dry_run                              = false,
   Array $path                                   = $kubernetes::default_path,
-  Optional[Array] $env                          = undef,
+  Optional[Array] $env                          = $kubernetes::environment,
   Optional[Array] $ignore_preflight_errors      = undef,
 ) {
   $kubeadm_init_flags = kubeadm_init_flags({

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -11,7 +11,7 @@ define kubernetes::kubeadm_join (
   Optional[String] $feature_gates          = undef,
   Optional[String] $cri_socket             = undef,
   Optional[String] $discovery_file         = undef,
-  Optional[Array] $env                     = undef,
+  Optional[Array] $env                     = $kubernetes::environment,
   Optional[Array] $ignore_preflight_errors = undef,
   Array $path                              = $kubernetes::default_path,
   Boolean $skip_ca_verification            = false,

--- a/manifests/wait_for_default_sa.pp
+++ b/manifests/wait_for_default_sa.pp
@@ -5,15 +5,17 @@ define kubernetes::wait_for_default_sa (
   Optional[Integer] $timeout   = undef,
   Optional[Integer] $tries     = 5,
   Optional[Integer] $try_sleep = 6,
+  Optional[Array] $env         = $kubernetes::environment,
 ) {
   $safe_namespace = shell_escape($namespace)
 
   # This prevents a known race condition https://github.com/kubernetes/kubernetes/issues/66689
   exec { "wait for default serviceaccount creation in ${safe_namespace}":
-    command   => "kubectl -n ${safe_namespace} get serviceaccount default -o name",
-    path      => $path,
-    timeout   => $timeout,
-    tries     => $tries,
-    try_sleep => $try_sleep,
+    command     => "kubectl -n ${safe_namespace} get serviceaccount default -o name",
+    path        => $path,
+    environment => $env,
+    timeout     => $timeout,
+    tries       => $tries,
+    try_sleep   => $try_sleep,
   }
 }


### PR DESCRIPTION
This is an alternative implementation of #257 which moves the kubectl environment out to the main class for later reuse. Setting that environment within cluster roles means that it's only available in routines called by cluster roles, and I think this is a general-purpose need.