### PR TITLE
removes redundant variables in the case of not using the cloud provider

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -108,12 +108,6 @@ class kubernetes::config::kubeadm (
       }
     }
   }
-  else {
-    $apiserver_merged_extra_arguments = $apiserver_extra_arguments
-    $apiserver_extra_volumes = {}
-    $controllermanager_merged_extra_arguments = []
-    $controllermanager_extra_volumes = {}
-  }
 
   # to_yaml emits a complete YAML document, so we must remove the leading '---'
   $kubeadm_extra_config_yaml = regsubst(to_yaml($kubeadm_extra_config), '^---\n', '')


### PR DESCRIPTION
This fixes an issue when a user is not using the cloud provider, and using kubeadm_extra_config to define controllerManagerExtraArgs and apiServerExtraVolumes the fields are defined twice making the yaml invalid. 

The variable being removed are only used inside the cloudprovider block, and can otherwise be defined by the users in the other fields available. They are not parameters usable by users in a manifest.

