### PR TITLE
Etcd hostname variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,14 @@ The system package name for installing etcd
 
 Defaults to `etcd-server`.
 
+#### `etcd_hostname`
+
+Specifies the name of the etcd instance.
+
+A Hiera is `kubernetes::etcd_hostname:"%{::fqdn}"`.
+
+Defaults to `$hostname`.
+
 #### `etcd_ip`
 
 Specifies the IP address etcd uses for communications.

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -14,6 +14,7 @@ class kubernetes::config::kubeadm (
   String $etcdpeer_crt = $kubernetes::etcdpeer_crt,
   String $etcdpeer_key = $kubernetes::etcdpeer_key,
   Array $etcd_peers = $kubernetes::etcd_peers,
+  String $etcd_hostname = $kubernetes::etcd_hostname,
   String $etcd_ip = $kubernetes::etcd_ip,
   String $cni_pod_cidr = $kubernetes::cni_pod_cidr,
   String $kube_api_advertise_address = $kubernetes::kube_api_advertise_address,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -365,7 +365,7 @@ class kubernetes (
   Boolean $manage_etcd                         = true,
   Optional[String] $kube_api_advertise_address = undef,
   Optional[String] $etcd_version               = '3.1.12',
-  Optional[String] $etcd_hostname              = $hostname,
+  Optional[String] $etcd_hostname              = $facts['hostname'],
   Optional[String] $etcd_ip                    = undef,
   Optional[Array] $etcd_peers                  = undef,
   Optional[String] $etcd_initial_cluster       = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,12 @@
 # [*runc_source*]
 #  The URL to download runc
 #  Defaults to https://github.com/opencontainers/runc/releases/download/v${runc_version}/runc.amd64
-#  
+#
+# [*etcd_hostname*]
+#   The name of the etcd instance.
+#   An example with hiera would be kubernetes::etcd_hostname: "%{::fqdn}"
+#   Defaults to hostname
+#
 # [*etcd_ip*]
 #   The ip address that you want etcd to use for communications.
 #   An example with hiera would be kubernetes::etcd_ip: "%{::ipaddress_enp0s8}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -360,6 +360,7 @@ class kubernetes (
   Boolean $manage_etcd                         = true,
   Optional[String] $kube_api_advertise_address = undef,
   Optional[String] $etcd_version               = '3.1.12',
+  Optional[String] $etcd_hostname              = $hostname,
   Optional[String] $etcd_ip                    = undef,
   Optional[Array] $etcd_peers                  = undef,
   Optional[String] $etcd_initial_cluster       = undef,

--- a/templates/etcd/etcd.service.erb
+++ b/templates/etcd/etcd.service.erb
@@ -11,7 +11,7 @@ RestartSec=5s
 LimitNOFILE=40000
 TimeoutStartSec=0
 
-ExecStart=/usr/local/bin/etcd --name <%= @$etcd_hostname %> \
+ExecStart=/usr/local/bin/etcd --name <%= @etcd_hostname %> \
     --data-dir /var/lib/etcd \
     --listen-client-urls https://<%= @etcd_ip %>:2379 \
     --advertise-client-urls https://<%= @etcd_ip %>:2379 \

--- a/templates/etcd/etcd.service.erb
+++ b/templates/etcd/etcd.service.erb
@@ -11,7 +11,7 @@ RestartSec=5s
 LimitNOFILE=40000
 TimeoutStartSec=0
 
-ExecStart=/usr/local/bin/etcd --name <%= @hostname %> \
+ExecStart=/usr/local/bin/etcd --name <%= @$etcd_hostname %> \
     --data-dir /var/lib/etcd \
     --listen-client-urls https://<%= @etcd_ip %>:2379 \
     --advertise-client-urls https://<%= @etcd_ip %>:2379 \


### PR DESCRIPTION
This PR makes the etcd instance name configurable.

It was always set to be the hostname before. We need it to be the FQDN instead.