### PR TITLE
MODULES-8947 fixing bugs and tests

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -5,7 +5,8 @@ class kubernetes::cluster_roles (
   Optional[Boolean] $worker = $kubernetes::worker,
   String $node_name = $kubernetes::node_name,
   String $container_runtime = $kubernetes::container_runtime,
-  Optional[Array] $ignore_preflight_errors = []
+  Optional[Array] $ignore_preflight_errors = $kubernetes::ignore_preflight_errors,
+  Optional[Array] $env = $kubernetes::environment,
 ) {
   if $container_runtime == 'cri_containerd' {
     $preflight_errors = flatten(['Service-Docker',$ignore_preflight_errors])
@@ -19,6 +20,7 @@ class kubernetes::cluster_roles (
   if $controller {
     kubernetes::kubeadm_init { $node_name:
       ignore_preflight_errors => $preflight_errors,
+      env                     => $env,
       }
     }
 
@@ -26,6 +28,7 @@ class kubernetes::cluster_roles (
     kubernetes::kubeadm_join { $node_name:
       cri_socket              => $cri_socket,
       ignore_preflight_errors => $preflight_errors,
+      env                     => $env,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@
 #
 # [*etcd_version*]
 #   The version of etcd that you would like to use.
-#   Defaults to 3.1.12
+#   Defaults to 3.2.18
 #
 # [*etcd_archive*]
 #  The name of the etcd archive
@@ -368,7 +368,7 @@ class kubernetes (
   Boolean $manage_docker                       = true,
   Boolean $manage_etcd                         = true,
   Optional[String] $kube_api_advertise_address = undef,
-  Optional[String] $etcd_version               = '3.1.12',
+  Optional[String] $etcd_version               = '3.2.18',
   Optional[String] $etcd_hostname              = $facts['hostname'],
   Optional[String] $etcd_ip                    = undef,
   Optional[Array] $etcd_peers                  = undef,
@@ -444,6 +444,7 @@ class kubernetes (
                                                     true    => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
                                                     default => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf'],
                                                   },
+  Optional[Array] $ignore_preflight_errors     = undef,
 ){
   if ! $facts['os']['family'] in ['Debian','RedHat'] {
     notify {"The OS family ${facts['os']['family']} is not supported by this module":}

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -5,7 +5,7 @@ define kubernetes::kubeadm_init (
   Boolean $dry_run                              = false,
   Array $path                                   = $kubernetes::default_path,
   Optional[Array] $env                          = $kubernetes::environment,
-  Optional[Array] $ignore_preflight_errors      = undef,
+  Optional[Array] $ignore_preflight_errors      = $kubernetes::ignore_preflight_errors,
 ) {
   $kubeadm_init_flags = kubeadm_init_flags({
     config                  => $config,

--- a/spec/acceptance/kubernetes_spec.rb
+++ b/spec/acceptance/kubernetes_spec.rb
@@ -12,6 +12,9 @@ describe 'the Kubernetes module' do
         class {'kubernetes':
           controller => true,
           schedule_on_controller => true,
+          environment  => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+          kubernetes_version => '1.13.5',
+          ignore_preflight_errors => ['NumCPU'],
         }
         "}
 
@@ -24,7 +27,7 @@ describe 'the Kubernetes module' do
         end
 
         it 'should install kube-dns' do
-          shell('KUBECONFIG=/etc/kubernetes/admin.conf kubectl get deploy --namespace kube-system kube-dns', :acceptable_exit_codes => [0])
+          shell('KUBECONFIG=/etc/kubernetes/admin.conf kubectl get deploy --namespace kube-system coredns', :acceptable_exit_codes => [0])
         end
       end
 
@@ -33,7 +36,7 @@ describe 'the Kubernetes module' do
         it 'can deploy an application into a namespace and expose it' do
           shell('sleep 180')
           shell('KUBECONFIG=/etc/kubernetes/admin.conf kubectl create -f /tmp/nginx.yml', :acceptable_exit_codes => [0]) do |r|
-            expect(r.stdout).to match(/namespace "nginx" created\ndeployment.apps "my-nginx" created\nservice "my-nginx" created\n/)
+            expect(r.stdout).to match(/namespace\/nginx created\ndeployment.apps\/my-nginx created\nservice\/my-nginx created\n/)
           end
         end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -41,11 +41,12 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'stahnma-epel'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'maestrodev-wget'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-translate', '--version', '1.0.0' ), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppet-archive'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'herculesteam-augeasproviders_sysctl'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'herculesteam-augeasproviders_core'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'camptocamp-kmod'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'herculesteam-augeasproviders_sysctl', '--version', '2.2.1'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'herculesteam-augeasproviders_core', '--version', '2.1.0'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'camptocamp-kmod', '--version', '2.2.0'), { :acceptable_exit_codes => [0,1] }
 
 
       # shell('echo "#{vmhostname}" > /etc/hostname')
@@ -131,11 +132,11 @@ EOS
 
         # Installing go, cfssl
         on(host, "cd  /etc/puppetlabs/code/modules/kubernetes;rm -rf Gemfile.lock;bundle install --path vendor/bundle", acceptable_exit_codes: [0]).stdout
-        on(host, "curl -o go.tar.gz https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz", acceptable_exit_codes: [0]).stdout
+        on(host, "curl -o go.tar.gz https://storage.googleapis.com/golang/go1.11.9.linux-amd64.tar.gz", acceptable_exit_codes: [0]).stdout
         on(host, "tar -C /usr/local -xzf go.tar.gz", acceptable_exit_codes: [0]).stdout
         on(host, "export PATH=$PATH:/usr/local/go/bin;go get -u github.com/cloudflare/cfssl/cmd/...", acceptable_exit_codes: [0]).stdout
         # Creating certs
-        on(host, "source ~/.bash_profile;rbenv global 2.3.1;rbenv local 2.3.1;export PATH=$PATH:/usr/local/go/bin;export PATH=$PATH:/root/go/bin;cd  /etc/puppetlabs/code/modules/kubernetes/tooling;./kube_tool.rb -o #{os} -v 1.10.2 -r #{runtime} -c #{cni} -i \"#{vmhostname}:#{vmipaddr}\" -t \"#{vmipaddr}\" -a \"#{vmipaddr}\" -d true", acceptable_exit_codes: [0]).stdout
+        on(host, "source ~/.bash_profile;rbenv global 2.3.1;rbenv local 2.3.1;export PATH=$PATH:/usr/local/go/bin;export PATH=$PATH:/root/go/bin;cd  /etc/puppetlabs/code/modules/kubernetes/tooling;./kube_tool.rb -o #{os} -v 1.13.5 -r #{runtime} -c #{cni} -i \"#{vmhostname}:#{vmipaddr}\" -t \"#{vmipaddr}\" -a \"#{vmipaddr}\" -d true", acceptable_exit_codes: [0]).stdout
         create_remote_file(host, "/etc/hosts", hosts_file)
         create_remote_file(host, "/tmp/nginx.yml", nginx)
         create_remote_file(host,"/etc/puppetlabs/puppet/hiera.yaml", hiera)
@@ -144,7 +145,9 @@ EOS
 
         if fact('osfamily') == 'Debian'
           on(host, 'sed -i /cni_network_provider/d /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
-          on(host, 'echo "kubernetes::cni_network_provider: https://cloud.weave.works/k8s/net?k8s-version=\$(kubectl version | base64 | tr -d \"\n\")\&env.IPALLOC_RANGE=100.32.0.0/12" >> /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'echo "kubernetes::cni_network_provider: https://cloud.weave.works/k8s/net?k8s-version=1.13.5" >> /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'echo "kubernetes::taint_master: false" >> /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'export KUBECONFIG=\'/etc/kubernetes/admin.conf\'', acceptable_exit_codes: [0]).stdout
         end
     end
   end

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -31,6 +31,12 @@ nodeRegistration:
 ---
 apiServer:
   timeoutForControlPlane: 4m0s
+<% if @apiserver_cert_extra_sans -%>
+  CertSANs:
+<% @apiserver_cert_extra_sans.each do |san| -%>
+- <%= san %>
+<% end -%>
+<% end -%>
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
@@ -82,12 +88,6 @@ controllerManagerExtraVolumes:
     mountPath: <%= config['mountPath'] %>
   <%- end -%>
 <%- end -%>
-<% if @apiserver_cert_extra_sans -%>
-apiServerCertSANs:
-<% @apiserver_cert_extra_sans.each do |san| -%>
-- <%= san %>
-<% end -%>
-<% end -%>
 <%- if @kubeadm_extra_config  -%>
 <%= @kubeadm_extra_config_yaml %>
 <%- end -%>


### PR DESCRIPTION
Request to review the following changes

- env settings specified for wait_for_default_sa & kube_addons.pp to set the env correctly
- upgraded the k8 version and go version on spec_helper_acceptance tests
- Updated the k8 version in the testcase
- Added the variable ignore_preflight_errors to init.pp
- updated the default value for etcd version
- coredns is default dns (hence modified the testcase for 1.13.5)

**K8 Acceptance test Results**
`he Kubernetes module
clean up before each test
kubernetes class
it should install the module and run
localhost $ scp /var/folders/4v/p90k7dqd65348jw6l6xrppdw0000gq/T/beaker20190425-35875-1puinxd ubuntu-1604-master:/tmp/apply_manifest.pp.dmlBKw {:ignore => }
should run
should install kubectl
should install kube-dns
application deployment
can deploy an application into a namespace and expose it
can access the deployed service
can delete a deployment

Finished in 26 minutes 14 seconds (files took 37.42 seconds to load)
6 examples, 0 failures`