### PR TITLE
Avoid log message about waiting for SA when it already exists

### DIFF
--- a/manifests/wait_for_default_sa.pp
+++ b/manifests/wait_for_default_sa.pp
@@ -12,6 +12,7 @@ define kubernetes::wait_for_default_sa (
   # This prevents a known race condition https://github.com/kubernetes/kubernetes/issues/66689
   exec { "wait for default serviceaccount creation in ${safe_namespace}":
     command     => "kubectl -n ${safe_namespace} get serviceaccount default -o name",
+    unless      => "kubectl -n ${safe_namespace} get serviceaccount default -o name",
     path        => $path,
     environment => $env,
     timeout     => $timeout,


### PR DESCRIPTION
Every run...

```
Notice: Kubernetes::Wait_for_default_sa[default]/Exec[wait for default serviceaccount creation in default]/returns: executed successfully
```