### PR TITLE
cluster name missing tag brackets in worker config

### DIFF
--- a/templates/v1alpha3/config_worker.yaml.erb
+++ b/templates/v1alpha3/config_worker.yaml.erb
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1alpha3
 caCertPath: /etc/kubernetes/pki/ca.crt
 kind: JoinConfiguration
 <%- if @kubernetes_cluster_name != "kubernetes"  -%>
-clusterName: @kubernetes_cluster_name
+clusterName: <%= @kubernetes_cluster_name %>
 <%- end -%>
 discoveryToken: <%= @discovery_token %>
 discoveryTokenAPIServers:

--- a/templates/v1beta1/config_worker.yaml.erb
+++ b/templates/v1beta1/config_worker.yaml.erb
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1beta1
 caCertPath: /etc/kubernetes/pki/ca.crt
 kind: JoinConfiguration
 <%- if @kubernetes_cluster_name != "kubernetes"  -%>
-clusterName: @kubernetes_cluster_name
+clusterName: <%= @kubernetes_cluster_name %>
 <%- end -%>
 
 discovery:


### PR DESCRIPTION
Currently produces this:

```
Notice: /Stage[main]/Kubernetes::Cluster_roles/Kubernetes::Kubeadm_join/Exec[kubeadm join]/returns: error converting YAML to JSON: yaml: line 4: found character that cannot start any token
```
Due to file contents
```
apiVersion: kubeadm.k8s.io/v1beta1
caCertPath: /etc/kubernetes/pki/ca.crt
kind: JoinConfiguration
clusterName: @kubernetes_cluster_name
```