### PR TITLE
Fixed duplicate tlsBootstrapToken in config_worker.yaml.erb for kubernetes 1.14

### DIFF
--- a/templates/v1beta1/config_worker.yaml.erb
+++ b/templates/v1beta1/config_worker.yaml.erb
@@ -13,8 +13,7 @@ discovery:
     unsafeSkipCAVerification: false
     caCertHashes:
     - 'sha256:<%= @discovery_token_hash %>'
-tlsBootstrapToken: <%= @tls_bootstrap_token %>
-token: <%= @discovery_token %> 
+token: <%= @discovery_token %>
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>


### PR DESCRIPTION
tlsBootstrapToken was defined 2 times for worker nodes