### PR TITLE
Add default k8s conf directory creation for worker

### DIFF
--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -28,6 +28,12 @@ class kubernetes::config::worker (
     default => 'v1alpha3',
   }
 
+  file { '/etc/kubernetes':
+    ensure  => directory,
+    mode    => '0600',
+    recurse => true,
+  }
+
   file { $config_file:
     ensure  => file,
     owner   => 'root',

--- a/spec/classes/config/worker_spec.rb
+++ b/spec/classes/config/worker_spec.rb
@@ -23,6 +23,12 @@ describe 'kubernetes::config::worker', :type => :class do
     }
   end
 
+  context 'with default params' do
+    let(:config_yaml) { YAML.safe_load(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').that_requires('File[/etc/kubernetes]') }
+  end
+
   context 'with version => 1.12.3 and node_name => foo and kubelet_extra_args => foo: bar' do
     let(:params) do
       {


### PR DESCRIPTION
Add resource to manage creation of the /etc/kubernetes default config
directory for worker nodes to ensure that similar to the controller
node it is always created before attempting to write any managed
configuration files. Test that the directory is a requirement of the
configuration file, as it should be added via autorequires thus
ensuring correct ordering.

First time manifest apply on a worker node will fail due to the config
file not being able to be written as the directory '/etc/kubernetes'
does not exist.

Subsequent runs do complete as the directory is created by a side
effect of another process being executed. However this prevents stand
up from pristine from succeeding.