### PR TITLE
Manage the control plane endpoint

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -1,6 +1,7 @@
 # Class kubernetes config kubeadm, populates kubeadm config file with params to bootstrap cluster
 class kubernetes::config::kubeadm (
   String $config_file = $kubernetes::config_file,
+  String $controller_address = $kubernetes::controller_address,
   Boolean $manage_etcd = $kubernetes::manage_etcd,
   String $etcd_install_method = $kubernetes::etcd_install_method,
   String $kubernetes_version  = $kubernetes::kubernetes_version,

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -267,5 +267,4 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[1]['controlPlaneEndpoint']).to include('foo')
     end
   end
-
 end

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -251,4 +251,21 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[1]['controllerManager']['extraVolumes']).to include('name' => 'foo', 'hostPath' => '/mnt', 'mountPath' => '/data')
     end
   end
+
+  context 'with version = 1.14' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.14.1',
+        'controller_address' => 'foo',
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it 'has foo in controlPlaneEndpoint' do
+      expect(config_yaml[1]['controlPlaneEndpoint']).to include('foo')
+    end
+  end
+
 end

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -54,7 +54,7 @@ apiServer:
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
-controlPlaneEndpoint: ""
+controlPlaneEndpoint: "<%= @controller_address %>"
 controllerManager:
 <%- if @controllermanager_merged_extra_arguments -%>
   extraArgs:


### PR DESCRIPTION
Without setting the `controlPlaneEndpoint` workers don't get the right api endpoint to talk to in HA scenarios.