### PR TITLE
Manage kernel modules for proxy_mode IPVS

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -20,6 +20,7 @@ class kubernetes::packages (
   Boolean $disable_swap                        = $kubernetes::disable_swap,
   Boolean $manage_kernel_modules               = $kubernetes::manage_kernel_modules,
   Boolean $manage_sysctl_settings              = $kubernetes::manage_sysctl_settings,
+  Optional[String] $proxy_mode                 = $kubernetes::proxy_mode,
 ) {
 
   $kube_packages = ['kubelet', 'kubectl', 'kubeadm']
@@ -48,6 +49,11 @@ class kubernetes::packages (
   } elsif $manage_kernel_modules {
 
     kmod::load { 'br_netfilter': }
+
+    if $proxy_mode == 'ipvs' {
+      $ipvs_modules = [ 'ip_vs', 'ip_vs_sh', 'ip_vs_rr', 'ip_vs_wrr', 'nf_conntrack_ipv4' ]
+      kmod::load { $ipvs_modules: }
+    }
 
   } elsif $manage_sysctl_settings {
     sysctl { 'net.bridge.bridge-nf-call-iptables':


### PR DESCRIPTION
Hi,

Manage kernel modules when proxy_mode IPVS is used.

If modules are not loaded, you'll have this warning:

```
	[WARNING RequiredIPVSKernelModulesAvailable]: 

The IPVS proxier may not be used because the following required kernel modules are not loaded: [ip_vs_sh ip_vs ip_vs_rr ip_vs_wrr]
or no builtin kernel IPVS support was found: map[ip_vs:{} ip_vs_rr:{} ip_vs_sh:{} ip_vs_wrr:{} nf_conntrack_ipv4:{}].
However, these modules may be loaded automatically by kube-proxy if they are available on your system.
To verify IPVS support:

   Run "lsmod | grep 'ip_vs|nf_conntrack'" and verify each of the above modules are listed.

If they are not listed, you can use the following methods to load them:

1. For each missing module run 'modprobe $modulename' (e.g., 'modprobe ip_vs', 'modprobe ip_vs_rr', ...)
2. If 'modprobe $modulename' returns an error, you will need to install the missing module support for your kernel.
```

Tested on Centos 7

Have a nice day
Zeysh