### PR TITLE
Support kubernetes_cluster_name in kubeadm 1.13+

### DIFF
--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -172,6 +172,20 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     }
   end
 
+  context 'with version = 1.13 and kubernetes_cluster_name => my_own_name' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.13.0',
+        'kubernetes_cluster_name' => 'my_own_name',
+      }
+    end
+
+    it {
+      is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+        .with_content(%r{clusterName: my_own_name\n})
+    }
+  end
+
   context 'with version = 1.14' do
     let(:params) do
       {

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -53,7 +53,9 @@ apiServer:
 <%- end -%>
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /etc/kubernetes/pki
-clusterName: kubernetes
+<%- if @kubernetes_cluster_name != "kubernetes"  -%>
+clusterName: <%= @kubernetes_cluster_name %>
+<%- end -%>
 controlPlaneEndpoint: "<%= @controller_address %>"
 controllerManager:
 <%- if @controllermanager_merged_extra_arguments -%>


### PR DESCRIPTION
The v1beta1 package config should honor kubernetes_cluster_name