### PR TITLE
set show_diff=>false on worker config

### DIFF
--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -35,10 +35,11 @@ class kubernetes::config::worker (
   }
 
   file { $config_file:
-    ensure  => file,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template("kubernetes/${template}/config_worker.yaml.erb"),
+    ensure    => file,
+    owner     => 'root',
+    group     => 'root',
+    mode      => '0644',
+    content   => template("kubernetes/${template}/config_worker.yaml.erb"),
+    show_diff => false,
   }
 }


### PR DESCRIPTION
This config file contains sensitive data (the bootstrap token), so it should be hidden from logs.