### PR TITLE
Manage front-proxy ca certs - fixes #275

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,19 @@ Defaults to `undef`.
 
 #### `kubernetes_ca_key`
 
-The clusters CA key. Must be passed as a string and not a file.
+The cluster's CA key. Must be passed as a string and not a file.
+
+Defaults to `undef`.
+
+#### `kubernetes_front_proxy_ca_crt`
+
+The cluster's front-proxy CA certificate. Must be passed as a string and not a file.
+
+Defaults to `undef`.
+
+#### `kubernetes_front_proxy_ca_key`
+
+The cluster's front-proxy CA key. Must be passed as a string and not a file.
 
 Defaults to `undef`.
 

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -27,6 +27,8 @@ class kubernetes::config::kubeadm (
   String $discovery_token_hash = $kubernetes::discovery_token_hash,
   String $kubernetes_ca_crt = $kubernetes::kubernetes_ca_crt,
   String $kubernetes_ca_key = $kubernetes::kubernetes_ca_key,
+  String $kubernetes_front_proxy_ca_crt = $kubernetes::kubernetes_front_proxy_ca_crt,
+  String $kubernetes_front_proxy_ca_key = $kubernetes::kubernetes_front_proxy_ca_key,
   String $container_runtime = $kubernetes::container_runtime,
   String $sa_pub = $kubernetes::sa_pub,
   String $sa_key = $kubernetes::sa_key,
@@ -53,7 +55,7 @@ class kubernetes::config::kubeadm (
 
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']
   $etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key','peer.crt', 'peer.key', 'server.crt', 'server.key']
-  $pki = ['ca.crt', 'ca.key','sa.pub','sa.key']
+  $pki = ['ca.crt','ca.key','front-proxy-ca.crt','front-proxy-ca.key','sa.pub','sa.key']
   $kube_dirs.each | String $dir |  {
     file  { $dir :
       ensure  => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,6 +196,14 @@
 #   The clusters ca key. Must be passed as a string not a file.
 #   Defaults to undef
 #
+# [*kubernetes_front_proxy_ca_crt*]
+#   The clusters front-proxy ca certificate. Must be passed as a string not a file.
+#   Defaults to undef
+#
+# [*kubernetes_front_proxy_ca_key*]
+#   The clusters front-proxy ca key. Must be passed as a string not a file.
+#   Defaults to undef
+#
 # [*sa_key*]
 #   The service account key. Must be passed as string not a file.
 #   Defaults to undef
@@ -408,6 +416,8 @@ class kubernetes (
   Integer $api_server_count                          = undef,
   String $kubernetes_ca_crt                          = undef,
   String $kubernetes_ca_key                          = undef,
+  String $kubernetes_front_proxy_ca_crt              = undef,
+  String $kubernetes_front_proxy_ca_key              = undef,
   String $token                                      = undef,
   String $discovery_token_hash                       = undef,
   String $sa_pub                                     = undef,

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -36,7 +36,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     kube_dirs = ['/etc/kubernetes', '/etc/kubernetes/manifests', '/etc/kubernetes/pki', '/etc/kubernetes/pki/etcd']
     etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key', 'peer.crt', 'peer.key', 'server.crt', 'server.key']
-    pki = ['ca.crt', 'ca.key', 'sa.pub', 'sa.key']
+    pki = ['ca.crt', 'ca.key', 'front-proxy-ca.crt', 'front-proxy-ca.key', 'sa.pub', 'sa.key']
 
     kube_dirs.each do |d|
       it { is_expected.to contain_file(d.to_s) }
@@ -69,7 +69,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     kube_dirs = ['/etc/kubernetes', '/etc/kubernetes/manifests', '/etc/kubernetes/pki', '/etc/kubernetes/pki/etcd']
     etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key', 'peer.crt', 'peer.key', 'server.crt', 'server.key']
-    pki = ['ca.crt', 'ca.key', 'sa.pub', 'sa.key']
+    pki = ['ca.crt', 'ca.key', 'front-proxy-ca.crt', 'front-proxy-ca.key', 'sa.pub', 'sa.key']
 
     kube_dirs.each do |d|
       it { is_expected.to contain_file(d.to_s) }

--- a/spec/fixtures/hiera/required_values.yaml
+++ b/spec/fixtures/hiera/required_values.yaml
@@ -6,6 +6,8 @@ kubernetes::etcdclient_crt: 'foo'
 kubernetes::api_server_count: 3
 kubernetes::kubernetes_ca_crt: 'foo'
 kubernetes::kubernetes_ca_key: 'foo'
+kubernetes::kubernetes_front_proxy_ca_crt: 'foo'
+kubernetes::kubernetes_front_proxy_ca_key: 'foo'
 kubernetes::discovery_token_hash: 'foo'
 kubernetes::token: 'foo'
 kubernetes::sa_pub: 'foo'

--- a/templates/pki/front-proxy-ca.crt.erb
+++ b/templates/pki/front-proxy-ca.crt.erb
@@ -1,0 +1,1 @@
+<%= @kubernetes_front_proxy_ca_crt %>

--- a/templates/pki/front-proxy-ca.key.erb
+++ b/templates/pki/front-proxy-ca.key.erb
@@ -1,0 +1,1 @@
+<%= @kubernetes_front_proxy_ca_key %>

--- a/tooling/kube_tool.rb
+++ b/tooling/kube_tool.rb
@@ -70,6 +70,7 @@ class Kube_tool
     CreateCerts.etcd_clients
     CreateCerts.etcd_server( hash[:etcd_initial_cluster])
     CreateCerts.kube_ca
+    CreateCerts.kube_front_proxy_ca
     CreateCerts.sa    
     CleanUp.remove_files
     CleanUp.clean_yaml( hash[:os])


### PR DESCRIPTION
This PR fixes the issue described in #275 by managing front-proxy-ca cert and key.
This means that metrics-server will work properly on a HA cluster deployed using the module.
The PR includes an update to the kube-tool docker container ruby code, therefore the kube-tool image on dockerhub should be updated accordingly.