### PR TITLE
manage etcd client certificates even if etcd is not managed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v5.0.0](https://github.com/puppetlabs/puppetlabs-kubernetes/tree/v5.0.0) (2019-07-24)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-kubernetes/compare/v4.0.1...v5.0.0)
+
+### Changed
+
+- \(FM-8100\) Update minimum supported Puppet version to 5.5.10 [\#291](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/291) ([sheenaajay](https://github.com/sheenaajay))
+
+### Added
+
+- Modify config\_version to kubernetes\_version mapping. Pre-req to supporting Kube 1.15 [\#308](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/308) ([nickperry](https://github.com/nickperry))
+- add support for cilium network provider [\#265](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/265) ([SimonHoenscheid](https://github.com/SimonHoenscheid))
+
+### Fixed
+
+- Manage front-proxy ca certs - fixes \#275 [\#321](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/321) ([nickperry](https://github.com/nickperry))
+- Expose ttl duration parameter [\#313](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/313) ([carabasdaniel](https://github.com/carabasdaniel))
+- make proxy mode configurable [\#297](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/297) ([mrwulf](https://github.com/mrwulf))
+- Fixed duplicate tlsBootstrapToken in config\_worker.yaml.erb for kubernetes 1.14 [\#287](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/287) ([Hillkorn](https://github.com/Hillkorn))
+
 ## [v4.0.1](https://github.com/puppetlabs/puppetlabs-kubernetes/tree/v4.0.1) (2019-05-13)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-kubernetes/compare/4.0.0...v4.0.1)

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development do
   gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]

--- a/README.md
+++ b/README.md
@@ -527,7 +527,19 @@ Defaults to `undef`.
 
 #### `kubernetes_ca_key`
 
-The clusters CA key. Must be passed as a string and not a file.
+The cluster's CA key. Must be passed as a string and not a file.
+
+Defaults to `undef`.
+
+#### `kubernetes_front_proxy_ca_crt`
+
+The cluster's front-proxy CA certificate. Must be passed as a string and not a file.
+
+Defaults to `undef`.
+
+#### `kubernetes_front_proxy_ca_key`
+
+The cluster's front-proxy CA key. Must be passed as a string and not a file.
 
 Defaults to `undef`.
 

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -27,6 +27,8 @@ class kubernetes::config::kubeadm (
   String $discovery_token_hash = $kubernetes::discovery_token_hash,
   String $kubernetes_ca_crt = $kubernetes::kubernetes_ca_crt,
   String $kubernetes_ca_key = $kubernetes::kubernetes_ca_key,
+  String $kubernetes_front_proxy_ca_crt = $kubernetes::kubernetes_front_proxy_ca_crt,
+  String $kubernetes_front_proxy_ca_key = $kubernetes::kubernetes_front_proxy_ca_key,
   String $container_runtime = $kubernetes::container_runtime,
   String $sa_pub = $kubernetes::sa_pub,
   String $sa_key = $kubernetes::sa_key,
@@ -53,7 +55,7 @@ class kubernetes::config::kubeadm (
 
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']
   $etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key','peer.crt', 'peer.key', 'server.crt', 'server.key']
-  $pki = ['ca.crt', 'ca.key','sa.pub','sa.key']
+  $pki = ['ca.crt','ca.key','front-proxy-ca.crt','front-proxy-ca.key','sa.pub','sa.key']
   $kube_dirs.each | String $dir |  {
     file  { $dir :
       ensure  => directory,

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -62,14 +62,15 @@ class kubernetes::config::kubeadm (
     }
   }
 
-  if $manage_etcd {
-    $etcd.each | String $etcd_files | {
-      file { "/etc/kubernetes/pki/etcd/${etcd_files}":
-        ensure  => present,
-        content => template("kubernetes/etcd/${etcd_files}.erb"),
-        mode    => '0600',
-      }
+  $etcd.each | String $etcd_files | {
+    file { "/etc/kubernetes/pki/etcd/${etcd_files}":
+      ensure  => present,
+      content => template("kubernetes/etcd/${etcd_files}.erb"),
+      mode    => '0600',
     }
+  }
+
+  if $manage_etcd {
     if $etcd_install_method == 'wget' {
       file { '/etc/systemd/system/etcd.service':
         ensure  => present,

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -24,6 +24,7 @@ class kubernetes::config::kubeadm (
   Integer $api_server_count = $kubernetes::api_server_count,
   String $etcd_version = $kubernetes::etcd_version,
   String $token = $kubernetes::token,
+  String $ttl_duration = $kubernetes::ttl_duration,
   String $discovery_token_hash = $kubernetes::discovery_token_hash,
   String $kubernetes_ca_crt = $kubernetes::kubernetes_ca_crt,
   String $kubernetes_ca_key = $kubernetes::kubernetes_ca_key,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -364,6 +364,10 @@
 # [*environment*]
 # The environment passed to kubectl commands.
 # Defaults to setting HOME and KUBECONFIG variables
+# 
+# [*ttl_duration*]
+# Availability of the token
+# Default to 24h 
 #
 # Authors
 # -------
@@ -419,6 +423,7 @@ class kubernetes (
   String $kubernetes_front_proxy_ca_crt              = undef,
   String $kubernetes_front_proxy_ca_key              = undef,
   String $token                                      = undef,
+  String $ttl_duration                               = '24h',
   String $discovery_token_hash                       = undef,
   String $sa_pub                                     = undef,
   String $sa_key                                     = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,6 +196,14 @@
 #   The clusters ca key. Must be passed as a string not a file.
 #   Defaults to undef
 #
+# [*kubernetes_front_proxy_ca_crt*]
+#   The clusters front-proxy ca certificate. Must be passed as a string not a file.
+#   Defaults to undef
+#
+# [*kubernetes_front_proxy_ca_key*]
+#   The clusters front-proxy ca key. Must be passed as a string not a file.
+#   Defaults to undef
+#
 # [*sa_key*]
 #   The service account key. Must be passed as string not a file.
 #   Defaults to undef
@@ -408,6 +416,8 @@ class kubernetes (
   Integer $api_server_count                          = undef,
   String $kubernetes_ca_crt                          = undef,
   String $kubernetes_ca_key                          = undef,
+  String $kubernetes_front_proxy_ca_crt              = undef,
+  String $kubernetes_front_proxy_ca_key              = undef,
   String $token                                      = undef,
   String $discovery_token_hash                       = undef,
   String $sa_pub                                     = undef,

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -1,7 +1,7 @@
 # Class kubernetes kube_addons
 class kubernetes::kube_addons (
 
-  String $cni_network_provider               = $kubernetes::cni_network_provider,
+  Optional[String] $cni_network_provider               = $kubernetes::cni_network_provider,
   Optional[String] $cni_rbac_binding         = $kubernetes::cni_rbac_binding,
   Boolean $install_dashboard                 = $kubernetes::install_dashboard,
   String $dashboard_version                  = $kubernetes::dashboard_version,
@@ -32,13 +32,15 @@ class kubernetes::kube_addons (
     }
   }
 
-  $shellsafe_provider = shell_escape($cni_network_provider)
-  exec { 'Install cni network provider':
-    command     => "kubectl apply -f ${shellsafe_provider}",
-    onlyif      => 'kubectl get nodes',
-    unless      => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'",
-    environment => $env,
+  if $cni_network_provider {
+    $shellsafe_provider = shell_escape($cni_network_provider)
+    exec { 'Install cni network provider':
+      command     => "kubectl apply -f ${shellsafe_provider}",
+      onlyif      => 'kubectl get nodes',
+      unless      => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'",
+      environment => $env,
     }
+  }
 
   if $schedule_on_controller {
 

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -26,7 +26,7 @@ class kubernetes::repos (
       'Debian': {
         $codename = fact('os.distro.codename')
         apt::source { 'kubernetes':
-          location => pick($kubernetes_apt_location,'http://apt.kubernetes.io'),
+          location => pick($kubernetes_apt_location,'https://apt.kubernetes.io'),
           repos    => pick($kubernetes_apt_repos,'main'),
           release  => pick($kubernetes_apt_release,"kubernetes-${codename}"),
           key      => {

--- a/metadata.json
+++ b/metadata.json
@@ -64,7 +64,7 @@
       "version_requirement": ">= 5.5.10 < 7.0.0"
     }
   ],
-  "pdk-version": "1.11.1",
+  "pdk-version": "1.12.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-gb096033"
+  "template-ref": "1.12.0-0-g55d9ae2"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-kubernetes",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "author": "Puppet",
   "summary": "The module installs and configures a Kubernetes cluster",
   "license": "Apache-2.0",

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -36,7 +36,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     kube_dirs = ['/etc/kubernetes', '/etc/kubernetes/manifests', '/etc/kubernetes/pki', '/etc/kubernetes/pki/etcd']
     etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key', 'peer.crt', 'peer.key', 'server.crt', 'server.key']
-    pki = ['ca.crt', 'ca.key', 'sa.pub', 'sa.key']
+    pki = ['ca.crt', 'ca.key', 'front-proxy-ca.crt', 'front-proxy-ca.key', 'sa.pub', 'sa.key']
 
     kube_dirs.each do |d|
       it { is_expected.to contain_file(d.to_s) }
@@ -69,7 +69,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     kube_dirs = ['/etc/kubernetes', '/etc/kubernetes/manifests', '/etc/kubernetes/pki', '/etc/kubernetes/pki/etcd']
     etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key', 'peer.crt', 'peer.key', 'server.crt', 'server.key']
-    pki = ['ca.crt', 'ca.key', 'sa.pub', 'sa.key']
+    pki = ['ca.crt', 'ca.key', 'front-proxy-ca.crt', 'front-proxy-ca.key', 'sa.pub', 'sa.key']
 
     kube_dirs.each do |d|
       it { is_expected.to contain_file(d.to_s) }

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -76,7 +76,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     end
 
     etcd.each do |f|
-      it { is_expected.not_to contain_file("/etc/kubernetes/pki/etcd/#{f}") }
+      it { is_expected.to contain_file("/etc/kubernetes/pki/etcd/#{f}") }
     end
 
     pki.each do |cert|

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -172,6 +172,20 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     }
   end
 
+  context 'with version = 1.13 and kubernetes_cluster_name => my_own_name' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.13.0',
+        'kubernetes_cluster_name' => 'my_own_name',
+      }
+    end
+
+    it {
+      is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+        .with_content(%r{clusterName: my_own_name\n})
+    }
+  end
+
   context 'with version = 1.14' do
     let(:params) do
       {

--- a/spec/fixtures/hiera/required_values.yaml
+++ b/spec/fixtures/hiera/required_values.yaml
@@ -6,6 +6,8 @@ kubernetes::etcdclient_crt: 'foo'
 kubernetes::api_server_count: 3
 kubernetes::kubernetes_ca_crt: 'foo'
 kubernetes::kubernetes_ca_key: 'foo'
+kubernetes::kubernetes_front_proxy_ca_crt: 'foo'
+kubernetes::kubernetes_front_proxy_ca_key: 'foo'
 kubernetes::discovery_token_hash: 'foo'
 kubernetes::token: 'foo'
 kubernetes::sa_pub: 'foo'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -153,7 +153,7 @@ EOS
 
         # Installing go, cfssl
         on(host, "cd  /etc/puppetlabs/code/modules/kubernetes;rm -rf Gemfile.lock;bundle install --path vendor/bundle", acceptable_exit_codes: [0]).stdout
-        on(host, "curl -o go.tar.gz https://storage.googleapis.com/golang/go1.11.9.linux-amd64.tar.gz", acceptable_exit_codes: [0]).stdout
+        on(host, "curl -o go.tar.gz https://storage.googleapis.com/golang/go1.12.9.linux-amd64.tar.gz", acceptable_exit_codes: [0]).stdout
         on(host, "tar -C /usr/local -xzf go.tar.gz", acceptable_exit_codes: [0]).stdout
         on(host, "export PATH=$PATH:/usr/local/go/bin;go get -u github.com/cloudflare/cfssl/cmd/...", acceptable_exit_codes: [0]).stdout
         # Creating certs

--- a/templates/pki/front-proxy-ca.crt.erb
+++ b/templates/pki/front-proxy-ca.crt.erb
@@ -1,0 +1,1 @@
+<%= @kubernetes_front_proxy_ca_crt %>

--- a/templates/pki/front-proxy-ca.key.erb
+++ b/templates/pki/front-proxy-ca.key.erb
@@ -1,0 +1,1 @@
+<%= @kubernetes_front_proxy_ca_key %>

--- a/templates/v1alpha3/config_kubeadm.yaml.erb
+++ b/templates/v1alpha3/config_kubeadm.yaml.erb
@@ -5,7 +5,7 @@ apiEndpoint:
 bootstrapTokens:
   - token: "<%= @token %>"
     description: "kubeadm bootstrap token"
-    ttl: "24h"
+    ttl: "<%= @ttl_duration %>"
     usages:
     - signing
     - authentication

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -4,7 +4,7 @@ bootstrapTokens:
   groups:
   - system:bootstrappers:kubeadm:default-node-token
   token: <%= @token %>
-  ttl: 24h0m0s
+  ttl: <%= @ttl_duration %>
   usages:
   - signing
   - authentication

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -53,7 +53,9 @@ apiServer:
 <%- end -%>
 apiVersion: kubeadm.k8s.io/v1beta1
 certificatesDir: /etc/kubernetes/pki
-clusterName: kubernetes
+<%- if @kubernetes_cluster_name != "kubernetes"  -%>
+clusterName: <%= @kubernetes_cluster_name %>
+<%- end -%>
 controlPlaneEndpoint: "<%= @controller_address %>"
 controllerManager:
 <%- if @controllermanager_merged_extra_arguments -%>

--- a/templates/v1beta1/config_worker.yaml.erb
+++ b/templates/v1beta1/config_worker.yaml.erb
@@ -1,19 +1,15 @@
 apiVersion: kubeadm.k8s.io/v1beta1
 caCertPath: /etc/kubernetes/pki/ca.crt
 kind: JoinConfiguration
-<%- if @kubernetes_cluster_name != "kubernetes"  -%>
-clusterName: <%= @kubernetes_cluster_name %>
-<%- end -%>
-
 discovery:
   timeout: 5m0s
+  tlsBootstrapToken: <%= @tls_bootstrap_token %>
   bootstrapToken:
     token: <%= @discovery_token %>
     apiServerEndpoint: '<%= @controller_address %>'
     unsafeSkipCAVerification: false
     caCertHashes:
     - 'sha256:<%= @discovery_token_hash %>'
-token: <%= @discovery_token %>
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
@@ -30,7 +26,3 @@ nodeRegistration:
     <%- @kubelet_extra_arguments.each do |arg| -%>
     <%= arg %>
     <%- end %>
-<% if @feature_gates -%>
-featureGates: <%= @feature_gates %>
-<% end -%>
-tlsBootstrapToken: <%= @tls_bootstrap_token %>

--- a/tooling/kube_tool.rb
+++ b/tooling/kube_tool.rb
@@ -70,6 +70,7 @@ class Kube_tool
     CreateCerts.etcd_clients
     CreateCerts.etcd_server( hash[:etcd_initial_cluster])
     CreateCerts.kube_ca
+    CreateCerts.kube_front_proxy_ca
     CreateCerts.sa    
     CleanUp.remove_files
     CleanUp.clean_yaml( hash[:os])


### PR DESCRIPTION
Currently, kubeadm fails because etcd client certificates are not installed when mange_etcd set to false. That pushes customers to add these files externally which is not the best option, because SSL directory is managed with this module.

What I think is that this module should still manage etcd client certificates, because these PKI files are the requirement of kubeadm.