### PR TITLE
Fix repository location for Ubuntu

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -26,7 +26,7 @@ class kubernetes::repos (
       'Debian': {
         $codename = fact('os.distro.codename')
         apt::source { 'kubernetes':
-          location => pick($kubernetes_apt_location,'http://apt.kubernetes.io'),
+          location => pick($kubernetes_apt_location,'https://apt.kubernetes.io'),
           repos    => pick($kubernetes_apt_repos,'main'),
           release  => pick($kubernetes_apt_release,"kubernetes-${codename}"),
           key      => {


### PR DESCRIPTION
The kubernetes apt repository uses https and thus the defaults should reflect that.
Fixes: #334