### PR TITLE
Use correct apt release on Debian/Ubuntu

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -28,7 +28,7 @@ class kubernetes::repos (
         apt::source { 'kubernetes':
           location => pick($kubernetes_apt_location,'http://apt.kubernetes.io'),
           repos    => pick($kubernetes_apt_repos,'main'),
-          release  => pick($kubernetes_apt_release,"kubernetes-xenial"),
+          release  => pick($kubernetes_apt_release,'kubernetes-xenial'),
           key      => {
             'id'     => pick($kubernetes_key_id,'54A647F9048D5688D7DA2ABE6A030B21BA07F4FB'),
             'source' => pick($kubernetes_key_source,'https://packages.cloud.google.com/apt/doc/apt-key.gpg'),

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -28,7 +28,7 @@ class kubernetes::repos (
         apt::source { 'kubernetes':
           location => pick($kubernetes_apt_location,'http://apt.kubernetes.io'),
           repos    => pick($kubernetes_apt_repos,'main'),
-          release  => pick($kubernetes_apt_release,"kubernetes-${codename}"),
+          release  => pick($kubernetes_apt_release,"kubernetes-xenial"),
           key      => {
             'id'     => pick($kubernetes_key_id,'54A647F9048D5688D7DA2ABE6A030B21BA07F4FB'),
             'source' => pick($kubernetes_key_source,'https://packages.cloud.google.com/apt/doc/apt-key.gpg'),


### PR DESCRIPTION
The kubernetes Debian repositories do not make use of codename-specific repositories. Instead a version for all supported releases is available in the "kubernetes-xenial" component. 

This change hardcodes this component name as the default accordingly. Of course this might break in the future, but since the value can be overriden via a parameter and this change makes the defaults work on a larger set of distributions (e.g. Ubuntu Bionic but probably also Debian) it seems to be a viable solution anyway.

Fixes: #335 