### PR TITLE
Adding all IPs for etcd servers to etcd server cert

### DIFF
--- a/tooling/Dockerfile
+++ b/tooling/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine3.7
+FROM golang:1.12.13-alpine3.9
 
 ENV GOPATH /go
 ENV USER root


### PR DESCRIPTION
fixes log entries
```error “remote error: tls: bad certificate”, ServerName “”```
and adds all IPs for etcd servers to etcd server cert