### PR TITLE
Add support for readOnly and pathType fields on volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ apiserver_extra_volumes => {
   'volume-name' => {
     hostPath  => '/data',
     mountPath => '/data',
+    readOnly: => 'false',
+    pathType: => 'DirectoryOrCreate'
   },
 }
 ```
@@ -286,6 +288,8 @@ controllermanager_extra_volumes => {
   'volume-name' => {
     hostPath  => '/data',
     mountPath => '/data',
+    readOnly: => 'false',
+    pathType: => 'DirectoryOrCreate'
   },
 }
 ```

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -232,6 +232,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
           'foo' => {
             'hostPath'  => '/mnt',
             'mountPath' => '/data',
+            'readOnly' => false,
+            'pathType' => 'Directory',
           },
         },
       }
@@ -241,7 +243,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it 'has hostPath: /mnt in API server extra volumes' do
-      expect(config_yaml[1]['apiServer']['extraVolumes']).to include('name' => 'foo', 'hostPath' => '/mnt', 'mountPath' => '/data')
+      expect(config_yaml[1]['apiServer']['extraVolumes']).to include('name' => 'foo', 'hostPath' => '/mnt', 'mountPath' => '/data', 'readOnly' => false, 'pathType' => 'Directory')
     end
   end
 
@@ -253,6 +255,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
           'foo' => {
             'hostPath'  => '/mnt',
             'mountPath' => '/data',
+            'readOnly' => false,
+            'pathType' => 'Directory',
           },
         },
       }
@@ -262,7 +266,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it 'has hostPath: /mnt in controller manager extra volumes' do
-      expect(config_yaml[1]['controllerManager']['extraVolumes']).to include('name' => 'foo', 'hostPath' => '/mnt', 'mountPath' => '/data')
+      expect(config_yaml[1]['controllerManager']['extraVolumes']).to include('name' => 'foo', 'hostPath' => '/mnt', 'mountPath' => '/data', 'readOnly' => false, 'pathType' => 'Directory')
     end
   end
 

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -49,6 +49,8 @@ apiServer:
   - name: <%= name %>
     hostPath: <%= config['hostPath'] %>
     mountPath: <%= config['mountPath'] %>
+    readOnly: <%= config['readOnly'] %>
+    pathType: <%= config['pathType'] %>
   <%- end -%>
 <%- end -%>
 apiVersion: kubeadm.k8s.io/v1beta1
@@ -70,6 +72,8 @@ controllerManager:
   - name: <%= name %>
     hostPath: <%= config['hostPath'] %>
     mountPath: <%= config['mountPath'] %>
+    readOnly: <%= config['readOnly'] %>
+    pathType: <%= config['pathType'] %>
   <%- end -%>
 <%- end -%>
 dns:

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -51,6 +51,8 @@ apiServer:
   - name: <%= name %>
     hostPath: <%= config['hostPath'] %>
     mountPath: <%= config['mountPath'] %>
+    readOnly: <%= config['readOnly'] %>
+    pathType: <%= config['pathType'] %>
   <%- end -%>
 <%- end -%>
 apiVersion: kubeadm.k8s.io/v1beta2
@@ -72,6 +74,8 @@ controllerManager:
   - name: <%= name %>
     hostPath: <%= config['hostPath'] %>
     mountPath: <%= config['mountPath'] %>
+    readOnly: <%= config['readOnly'] %>
+    pathType: <%= config['pathType'] %>
   <%- end -%>
 <%- end -%>
 dns:


### PR DESCRIPTION
This fixes https://github.com/puppetlabs/puppetlabs-kubernetes/issues/302 and https://github.com/puppetlabs/puppetlabs-kubernetes/issues/304.

Without this PR, the module cannot create functioning volume mounts into the control-plane pods. It is therefore not possible to, for example, mount an audit policy file or mount a directory to write audit logs to.