### PR TITLE
Add docker_extra_daemon_config for use when managing docker

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -337,6 +337,10 @@
 #  The URL for the Docker yum repo gpg key
 #  Defaults to https://yum.dockerproject.org/gpg
 #
+# [*docker_extra_daemon_config*]
+#  Extra configuration to be added to `/etc/docker/daemon.json`
+#  Defaults to undef
+#
 # [*docker_log_max_file*]
 #  The maximum number of log files that can be present.
 #  Defaults to 1. See https://docs.docker.com/config/containers/logging/json-file/
@@ -373,10 +377,10 @@
 # [*environment*]
 # The environment passed to kubectl commands.
 # Defaults to setting HOME and KUBECONFIG variables
-# 
+#
 # [*ttl_duration*]
 # Availability of the token
-# Default to 24h 
+# Default to 24h
 #
 # Authors
 # -------
@@ -474,6 +478,7 @@ class kubernetes (
   Optional[String] $docker_yum_gpgkey                = undef,
   Optional[String] $docker_key_id                    = undef,
   Optional[String] $docker_key_source                = undef,
+  Optional[String] $docker_extra_daemon_config       = undef,
   String $docker_log_max_file                        = '1',
   String $docker_log_max_size                        = '100m',
   Boolean $disable_swap                              = true,

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -17,6 +17,7 @@ describe 'kubernetes::packages', :type => :class do
     let(:pre_condition) {
        '
        exec { \'kubernetes-systemd-reload\': }
+       service { \'docker\': }
        '
     }
     let(:params) do
@@ -31,6 +32,7 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
+        'docker_extra_daemon_config' => '',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -52,6 +54,7 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubelet').with_ensure('1.10.2')}
     it { should contain_package('kubectl').with_ensure('1.10.2')}
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
+    it { should contain_file('/etc/docker')}
     it { should contain_file('/etc/docker/daemon.json')}
     it { should contain_file('/etc/systemd/system/docker.service.d')}
   end
@@ -73,6 +76,7 @@ describe 'kubernetes::packages', :type => :class do
     let(:pre_condition) {
        '
        exec { \'kubernetes-systemd-reload\': }
+       service { \'docker\': }
        '
     }
     let(:params) do
@@ -87,6 +91,7 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
+        'docker_extra_daemon_config' => 'dummy',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -109,7 +114,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubelet').with_ensure('1.10.2')}
     it { should contain_package('kubectl').with_ensure('1.10.2')}
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
-    it { should contain_file('/etc/docker/daemon.json')}
+    it { should contain_file('/etc/docker')}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*dummy\s*/)}
     it { should contain_file('/etc/systemd/system/docker.service.d')}
   end
 
@@ -148,6 +154,7 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
+        'docker_extra_daemon_config' => '',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => false,
@@ -171,7 +178,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubelet').with_ensure('1.10.2-00')}
     it { should contain_package('kubectl').with_ensure('1.10.2-00')}
     it { should contain_package('kubeadm').with_ensure('1.10.2-00')}
-    it { should_not contain_file('/etc/docker/daemon.json')}
+    it { should_not contain_file('/etc/docker')}
+    it { should_not contain_file('/etc/docker/daemon.json').without_content(/\s*"default-runtime": "runc"\s*/)}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
   end
 
@@ -211,6 +219,7 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
+        'docker_extra_daemon_config' => '"default-runtime": "runc"',
         'disable_swap' => true,
         'manage_docker' => false,
         'manage_etcd' => true,
@@ -232,7 +241,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubectl').with_ensure('1.10.2')}
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
     it { should_not contain_package('docker-engine').with_ensure('17.03.0~ce-0~ubuntu-xenial')}
-    it { should_not contain_file('/etc/docker/daemon.json')}
+    it { should_not contain_file('/etc/docker')}
+    it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"default-runtime": "runc"\s*/)}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
   end
 
@@ -271,6 +281,7 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
+        'docker_extra_daemon_config' => '"default-runtime": "runc"',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -288,7 +299,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
     it { should contain_exec('disable swap')}
-    it { should_not contain_file('/etc/docker/daemon.json')}
+    it { should_not contain_file('/etc/docker')}
+    it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"default-runtime": "runc"\s*/)}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
   end
 end

--- a/templates/docker/daemon_debian.json.erb
+++ b/templates/docker/daemon_debian.json.erb
@@ -5,5 +5,8 @@
     "max-size": "<%= @docker_log_max_size %>",
     "max-file": "<%= @docker_log_max_file %>"
   },
+  <%- if @docker_extra_daemon_config -%>
+  <%= @docker_extra_daemon_config -%>,
+  <%- end -%>
   "storage-driver": "overlay2"
 }

--- a/templates/docker/daemon_redhat.json.erb
+++ b/templates/docker/daemon_redhat.json.erb
@@ -5,6 +5,9 @@
     "max-size": "<%= @docker_log_max_size %>",
     "max-file": "<%= @docker_log_max_file %>"
   },
+  <%- if @docker_extra_daemon_config -%>
+  <%= @docker_extra_daemon_config -%>,
+  <%- end -%>
   "storage-driver": "overlay2",
   "storage-opts": [
     "overlay2.override_kernel_check=true"


### PR DESCRIPTION
I had been customizing `/etc/docker/daemon.json` myself to inject registry mirrors and runtime config. This PR allows others to do the same without adding a bunch of individual params.