### PR TITLE
Allow setting metricsBindAddress

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -48,6 +48,7 @@ class kubernetes::config::kubeadm (
   String $image_repository = $kubernetes::image_repository,
   String $cgroup_driver = $kubernetes::cgroup_driver,
   String $proxy_mode = $kubernetes::proxy_mode,
+  Stdlib::IP::Address $metrics_bind_address = $kubernetes::metrics_bind_address,
 ) {
 
   if !($proxy_mode in ['', 'userspace', 'iptables', 'ipvs', 'kernelspace']) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -382,6 +382,10 @@
 # Availability of the token
 # Default to 24h
 #
+# [*metrics_bind_address*]
+# Set the metricsBindAddress (to allow prometheus)
+# Default to 127.0.0.1
+#
 # Authors
 # -------
 #
@@ -496,6 +500,7 @@ class kubernetes (
                                                           default => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf'],
                                                         },
   Optional[Array] $ignore_preflight_errors           = undef,
+  Stdlib::IP::Address $metrics_bind_address          = '127.0.0.1',
 ){
   if ! $facts['os']['family'] in ['Debian','RedHat'] {
     notify {"The OS family ${facts['os']['family']} is not supported by this module":}

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -298,4 +298,47 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[2]['mode']).to include('ipvs')
     end
   end
+
+  context 'with metrics_bind_address = 0.0.0.0 with version 1.14.2' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.14.2',
+        'metrics_bind_address' => '0.0.0.0',
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it 'has 0.0.0.0 in metrics_bind_address:' do
+      expect(config_yaml[2]['metricsBindAddress']).to include('0.0.0.0')
+    end
+  end
+
+  context 'with metrics_bind_address = 0.0.0.0 with version 1.16.3' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.16.3',
+        'metrics_bind_address' => '0.0.0.0',
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it 'has 0.0.0.0 in metrics_bind_address:' do
+      expect(config_yaml[2]['metricsBindAddress']).to include('0.0.0.0')
+    end
+  end
+
+  context 'with metrics_bind_address = invalid' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.14.2',
+        'metrics_bind_address' => 'invalid',
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{metrics_bind_address}) }
+  end
 end

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -128,7 +128,7 @@ ipvs:
   scheduler: ""
   syncPeriod: 30s
 kind: KubeProxyConfiguration
-metricsBindAddress: 127.0.0.1:10249
+metricsBindAddress: <%= @metrics_bind_address %>:10249
 mode: "<%= @proxy_mode %>"
 nodePortAddresses: null
 oomScoreAdj: -999

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -129,7 +129,7 @@ ipvs:
   scheduler: ""
   syncPeriod: 30s
 kind: KubeProxyConfiguration
-metricsBindAddress: 127.0.0.1:10249
+metricsBindAddress: <%= @metrics_bind_address %>:10249
 mode: "<%= @proxy_mode %>"
 nodePortAddresses: null
 oomScoreAdj: -999


### PR DESCRIPTION
This allows the ability to override the metricsBindAddress, which is currently hard coded to 127.0.0.1. This does not change the default, but allows it to be set.

Tommy