### PR TITLE
Create client certificates per server with SAN values

### DIFF
--- a/tooling/kube_tool.rb
+++ b/tooling/kube_tool.rb
@@ -68,7 +68,7 @@ class Kube_tool
     PreChecks.checks
     CreateCerts.etcd_ca
     CreateCerts.etcd_clients
-    CreateCerts.etcd_server( hash[:etcd_initial_cluster])
+    CreateCerts.etcd_certificates( hash[:etcd_initial_cluster])
     CreateCerts.kube_ca
     CreateCerts.kube_front_proxy_ca
     CreateCerts.sa    


### PR DESCRIPTION
## Description
Currently, the client certificate that is created by the kubetool is shared between all controller nodes without any SAN (Subject Alternative Name). Checking etcd logs when the "master" etcd controller goes down show the following error:

`rejected connection from "10.10.10.104:43816" (error "remote error: tls: bad certificate", ServerName "")`

Because of that error, it's not possible anymore to call Kubernetes cluster using kubectl until the etcd node is back.

The fix implemented simply creates one client certificate per K8S controller node with SAN fields with correct values (DNS name and IP). After a few etcd failover tests, the etcd cluster continues to work and kubectl is working, too.

## Environment
 - Kubernetes version: 1.15.0
 - etcd version: 3.4.3
 - CentOS Linux release 7.6.1810 (Core)