### PR TITLE
Update etcd repo from coreos to etcd-io

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -476,7 +476,7 @@ class kubernetes (
     "https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive}",
   String $etcd_archive                               = "etcd-v${etcd_version}-linux-amd64.tar.gz",
   String $etcd_package_name                          = 'etcd-server',
-  String $etcd_source                                = "https://github.com/coreos/etcd/releases/download/v${etcd_version}/${etcd_archive}",
+  String $etcd_source                                = "https://github.com/etcd-io/etcd/releases/download/v${etcd_version}/${etcd_archive}",
   String $etcd_install_method                        = 'wget',
   Optional[String] $kubernetes_apt_location          = undef,
   Optional[String] $kubernetes_apt_release           = undef,


### PR DESCRIPTION
Seems like Etcd project has been moved from coreos to etcd-io: https://github.com/etcd-io/etcd/releases

Signed-off-by: Andrey Voronkov <avoronkov@enapter.com>