### PR TITLE
pdksync - Use abs instead of vmpooler to provision test resources

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -12,5 +12,5 @@
     provisioner: vagrant
     images: ['ubuntu/xenial64', 'debian/stretch64', 'centos/7']
   release_checks:
-    provisioner: vmpooler
+    provisioner: abs
     images: ['redhat-7-x86_64', 'redhat-8-x86_64', 'centos-7-x86_64', 'ubuntu-1604-x86_64']

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'serverspec'
+
 require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 


### PR DESCRIPTION
Use abs instead of vmpooler to provision test resources
pdk version: `1.17.0` 
