### PR TITLE
Delegated PKI and adapt to k8s 1.15.3+

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'

--- a/lib/puppet/parser/functions/kubeadm_join_flags.rb
+++ b/lib/puppet/parser/functions/kubeadm_join_flags.rb
@@ -8,7 +8,8 @@ module Puppet::Parser::Functions
     opts = args[0] || {}
     flags = []
     flags << "'#{opts['controller_address']}'" if opts['controller_address'] && opts['controller_address'].to_s != 'undef'
-    flags << "--config '#{opts['config']}'" if opts['config'] && opts['config'].to_s != 'undef'
+    # --config is exclusive with --discovery-file, so if --discovery-file is present, don't use --config
+    flags << "--config '#{opts['config']}'" if opts['config'] && opts['config'].to_s != 'undef' && !(opts['discovery_file'] && opts['discovery_file'].to_s != 'undef')
     flags << "--cri-socket '#{opts['cri_socket']}'" if opts['cri_socket'] && opts['cri_socket'].to_s != 'undef'
     flags << "--discovery-file '#{opts['discovery_file']}'" if opts['discovery_file'] && opts['discovery_file'].to_s != 'undef'
     flags << "--discovery-token '#{opts['discovery_token']}'" if opts['discovery_token'] && opts['discovery_token'].to_s != 'undef'

--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -5,6 +5,7 @@ class kubernetes::cluster_roles (
   Optional[Boolean] $worker = $kubernetes::worker,
   String $node_name = $kubernetes::node_name,
   String $container_runtime = $kubernetes::container_runtime,
+  Optional[String] $join_discovery_file = $kubernetes::join_discovery_file,
   Optional[Array] $ignore_preflight_errors = $kubernetes::ignore_preflight_errors,
   Optional[Array] $env = $kubernetes::environment,
 ) {
@@ -28,6 +29,7 @@ class kubernetes::cluster_roles (
     kubernetes::kubeadm_join { $node_name:
       cri_socket              => $cri_socket,
       ignore_preflight_errors => $preflight_errors,
+      discovery_file          => $join_discovery_file,
       env                     => $env,
     }
   }

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -8,7 +8,6 @@ class kubernetes::config::kubeadm (
   String $etcd_install_method = $kubernetes::etcd_install_method,
   String $kubernetes_version  = $kubernetes::kubernetes_version,
   String $kubernetes_cluster_name  = $kubernetes::kubernetes_cluster_name,
-  String $kubernetes_dns_domain  = $kubernetes::kubernetes_dns_domain,
   Optional[String] $etcd_ca_key = $kubernetes::etcd_ca_key,
   Optional[String] $etcd_ca_crt = $kubernetes::etcd_ca_crt,
   Optional[String] $etcdclient_key = $kubernetes::etcdclient_key,

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -8,6 +8,7 @@ class kubernetes::config::kubeadm (
   String $etcd_install_method = $kubernetes::etcd_install_method,
   String $kubernetes_version  = $kubernetes::kubernetes_version,
   String $kubernetes_cluster_name  = $kubernetes::kubernetes_cluster_name,
+  String $kubernetes_dns_domain  = $kubernetes::kubernetes_dns_domain,
   Optional[String] $etcd_ca_key = $kubernetes::etcd_ca_key,
   Optional[String] $etcd_ca_crt = $kubernetes::etcd_ca_crt,
   Optional[String] $etcdclient_key = $kubernetes::etcdclient_key,
@@ -38,8 +39,8 @@ class kubernetes::config::kubeadm (
   Optional[String] $kubernetes_front_proxy_ca_crt = $kubernetes::kubernetes_front_proxy_ca_crt,
   Optional[String] $kubernetes_front_proxy_ca_key = $kubernetes::kubernetes_front_proxy_ca_key,
   String $container_runtime = $kubernetes::container_runtime,
-  String $sa_pub = $kubernetes::sa_pub,
-  String $sa_key = $kubernetes::sa_key,
+  Optional[String] $sa_pub = $kubernetes::sa_pub,
+  Optional[String] $sa_key = $kubernetes::sa_key,
   Optional[Array] $apiserver_cert_extra_sans = $kubernetes::apiserver_cert_extra_sans,
   Optional[Array] $apiserver_extra_arguments = $kubernetes::apiserver_extra_arguments,
   Optional[Array] $controllermanager_extra_arguments = $kubernetes::controllermanager_extra_arguments,
@@ -159,10 +160,10 @@ class kubernetes::config::kubeadm (
   $kubelet_extra_config_alpha1_yaml = regsubst(to_yaml($kubelet_extra_config_alpha1), '^---\n', '')
 
   $config_version = $kubernetes_version ? {
-    /1.1(0|1)/   => 'v1alpha1',
-    /1.12/       => 'v1alpha3',
-    /1.1(3|4|5)/ => 'v1beta1',
-    default      => 'v1beta2',
+    /1\.1(0|1)/          => 'v1alpha1',
+    /1\.12/              => 'v1alpha3',
+    /1\.1(3|4|5\.[012])/ => 'v1beta1',
+    default              => 'v1beta2',
   }
 
   file { $config_file:

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -4,33 +4,39 @@ class kubernetes::config::kubeadm (
   String $controller_address = $kubernetes::controller_address,
   String $dns_domain = $kubernetes::dns_domain,
   Boolean $manage_etcd = $kubernetes::manage_etcd,
+  Boolean $delegated_pki = $kubernetes::delegated_pki,
   String $etcd_install_method = $kubernetes::etcd_install_method,
   String $kubernetes_version  = $kubernetes::kubernetes_version,
   String $kubernetes_cluster_name  = $kubernetes::kubernetes_cluster_name,
-  String $etcd_ca_key = $kubernetes::etcd_ca_key,
-  String $etcd_ca_crt = $kubernetes::etcd_ca_crt,
-  String $etcdclient_key = $kubernetes::etcdclient_key,
-  String $etcdclient_crt = $kubernetes::etcdclient_crt,
-  String $etcdserver_crt = $kubernetes::etcdserver_crt,
-  String $etcdserver_key = $kubernetes::etcdserver_key,
-  String $etcdpeer_crt = $kubernetes::etcdpeer_crt,
-  String $etcdpeer_key = $kubernetes::etcdpeer_key,
+  Optional[String] $etcd_ca_key = $kubernetes::etcd_ca_key,
+  Optional[String] $etcd_ca_crt = $kubernetes::etcd_ca_crt,
+  Optional[String] $etcdclient_key = $kubernetes::etcdclient_key,
+  Optional[String] $etcdclient_crt = $kubernetes::etcdclient_crt,
+  Optional[String] $etcdserver_crt = $kubernetes::etcdserver_crt,
+  Optional[String] $etcdserver_key = $kubernetes::etcdserver_key,
+  Optional[String] $etcdpeer_crt = $kubernetes::etcdpeer_crt,
+  Optional[String] $etcdpeer_key = $kubernetes::etcdpeer_key,
   Array $etcd_peers = $kubernetes::etcd_peers,
   String $etcd_hostname = $kubernetes::etcd_hostname,
   String $etcd_ip = $kubernetes::etcd_ip,
   String $cni_pod_cidr = $kubernetes::cni_pod_cidr,
+  Integer $kube_api_bind_port = $kubernetes::kube_api_bind_port,
   String $kube_api_advertise_address = $kubernetes::kube_api_advertise_address,
-  String $etcd_initial_cluster = $kubernetes::etcd_initial_cluster,
+  Optional[String] $etcd_initial_cluster = $kubernetes::etcd_initial_cluster,
+  Optional[String] $etcd_discovery_srv = $kubernetes::etcd_discovery_srv,
   String $etcd_initial_cluster_state = $kubernetes::etcd_initial_cluster_state,
+  String $etcd_compaction_method = $kubernetes::etcd_compaction_method,
+  Variant[Integer,String] $etcd_compaction_retention = $kubernetes::etcd_compaction_retention,
   Integer $api_server_count = $kubernetes::api_server_count,
   String $etcd_version = $kubernetes::etcd_version,
+  Integer $etcd_max_wals = $kubernetes::etcd_max_wals,
   String $token = $kubernetes::token,
   String $ttl_duration = $kubernetes::ttl_duration,
   String $discovery_token_hash = $kubernetes::discovery_token_hash,
-  String $kubernetes_ca_crt = $kubernetes::kubernetes_ca_crt,
-  String $kubernetes_ca_key = $kubernetes::kubernetes_ca_key,
-  String $kubernetes_front_proxy_ca_crt = $kubernetes::kubernetes_front_proxy_ca_crt,
-  String $kubernetes_front_proxy_ca_key = $kubernetes::kubernetes_front_proxy_ca_key,
+  Optional[String] $kubernetes_ca_crt = $kubernetes::kubernetes_ca_crt,
+  Optional[String] $kubernetes_ca_key = $kubernetes::kubernetes_ca_key,
+  Optional[String] $kubernetes_front_proxy_ca_crt = $kubernetes::kubernetes_front_proxy_ca_crt,
+  Optional[String] $kubernetes_front_proxy_ca_key = $kubernetes::kubernetes_front_proxy_ca_key,
   String $container_runtime = $kubernetes::container_runtime,
   String $sa_pub = $kubernetes::sa_pub,
   String $sa_key = $kubernetes::sa_key,
@@ -56,6 +62,10 @@ class kubernetes::config::kubeadm (
     fail('Invalid kube-proxy mode! Must be one of "", userspace, iptables, ipvs, kernelspace.')
   }
 
+  if !($etcd_discovery_srv or $etcd_initial_cluster) {
+    fail('One of $etcd_discovery_srv or $etcd_initial_cluster variables must be defined')
+  }
+
   $kube_dirs = ['/etc/kubernetes','/etc/kubernetes/manifests','/etc/kubernetes/pki','/etc/kubernetes/pki/etcd']
   $etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key','peer.crt', 'peer.key', 'server.crt', 'server.key']
   $pki = ['ca.crt','ca.key','front-proxy-ca.crt','front-proxy-ca.key','sa.pub','sa.key']
@@ -68,11 +78,13 @@ class kubernetes::config::kubeadm (
   }
 
   if $manage_etcd {
-    $etcd.each | String $etcd_files | {
-      file { "/etc/kubernetes/pki/etcd/${etcd_files}":
-        ensure  => present,
-        content => template("kubernetes/etcd/${etcd_files}.erb"),
-        mode    => '0600',
+    if !$delegated_pki {
+      $etcd.each | String $etcd_files | {
+        file { "/etc/kubernetes/pki/etcd/${etcd_files}":
+          ensure  => present,
+          content => template("kubernetes/etcd/${etcd_files}.erb"),
+          mode    => '0600',
+        }
       }
     }
     if $etcd_install_method == 'wget' {
@@ -88,11 +100,13 @@ class kubernetes::config::kubeadm (
     }
   }
 
-  $pki.each | String $pki_files | {
-    file {"/etc/kubernetes/pki/${pki_files}":
-      ensure  => present,
-      content => template("kubernetes/pki/${pki_files}.erb"),
-      mode    => '0600',
+  if !$delegated_pki {
+    $pki.each | String $pki_files | {
+      file {"/etc/kubernetes/pki/${pki_files}":
+        ensure  => present,
+        content => template("kubernetes/pki/${pki_files}.erb"),
+        mode    => '0600',
+      }
     }
   }
 

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -24,9 +24,9 @@ class kubernetes::config::worker (
   $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')
 
   $template = $kubernetes_version ? {
-    /1.12/       => 'v1alpha3',
-    /1.1(3|4|5)/ => 'v1beta1',
-    default      => 'v1beta2',
+    /1\.12/              => 'v1alpha3',
+    /1\.1(3|4|5\.[012])/ => 'v1beta1',
+    default              => 'v1beta2',
   }
 
   file { '/etc/kubernetes':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,11 +10,6 @@
 #   ie api server,
 #   Defaults to  1.10.2
 #
-# [*kubernetes_dns_domain*]
-#   The base DNS domain used by CoreDNS
-#   Only used by Kubernetes 1.12+
-#   Defaults to "cluster.local"
-#
 # [*kubernetes_cluster_name*]
 #   The name of the cluster, for use when multiple clusters are accessed from the same source
 #   Only used by Kubernetes 1.12+
@@ -442,7 +437,6 @@
 #
 class kubernetes (
   String $kubernetes_version                         = '1.10.2',
-  String $kubernetes_dns_domain                      = 'cluster.local',
   String $kubernetes_cluster_name                    = 'kubernetes',
   String $kubernetes_package_version                 = $facts['os']['family'] ? {
                                                           'Debian' => "${kubernetes_version}-00",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,10 @@
 #   Or to pin explicitly to a specific interface kubernetes::kube_api_advertise_address: "%{::ipaddress_enp0s8}"
 #   defaults to undef
 #
+# [*kube_api_bind_port*]
+#   Apiserver bind port
+#   Defaults to 6443
+#
 # [*etcd_version*]
 #   The version of etcd that you would like to use.
 #   Defaults to 3.2.18
@@ -132,6 +136,12 @@
 #                                  - 172.17.10.103
 #   Defaults to undef
 #
+# [*etcd_discovery_srv*]
+#    This will tell etcd to use DNS SRV discovery method. This option is exclusive with `etcd_initial_cluster`, taking precedence
+#    over it if both are present.
+#   An example with hiera would be kubernetes::etcd_discovery_srv: etcd-gen.example.org
+#   Defaults to undef
+#
 # [*etcd_initial_cluster*]
 #    This will tell etcd how many nodes will be in the cluster and is passed as a string.
 #   An example with hiera would be kubernetes::etcd_initial_cluster: etcd-kube-master=http://172.17.10.101:2380,etcd-kube-replica-master-01=http://172.17.10.210:2380,etcd-kube-replica-master-02=http://172.17.10.220:2380
@@ -141,6 +151,20 @@
 #     This will tell etcd the initial state of the cluster. Useful for adding a node to the cluster. Allowed values are
 #   "new" or "existing"
 #   Defaults to "new"
+#
+# [*etcd_compaction_retention*]
+#     This will tell etcd how much retention to be applied. This value can change depending on `etcd_compaction_method`. An integer or time string (i.e.: "5m") can be used in case of "periodic". Only integer allowed in case of "revision"
+#   Integer or String
+#   Defaults to 0 (disabled)
+#
+# [*etcd_compaction_method*]
+#     This will tell etcd the compaction method to be used.
+#   "periodic" or "revision"
+#   Defaults to "periodic"
+#
+# [*etcd_max_wals*]
+#     This will tell etcd how many WAL files to be kept
+#   Defaults to 5
 #
 # [*etcd_ca_key*]
 #   This is the ca certificate key data for the etcd cluster. This must be passed as string not as a file.
@@ -178,6 +202,10 @@
 #   A string array of extra arguments to be passed to the api server.
 #   Defaults to []
 #
+# [*apiserver_port*]
+#   Apiserver listening port
+#   Defaults to 6443
+#
 # [*apiserver_cert_extra_sans*]
 #   A string array of Subhect Alternative Names for the api server certificates.
 #   Defaults to []
@@ -193,6 +221,10 @@
 # [*controllermanager_extra_volumes*]
 #   A hash of extra volume mounts mounted on the controller manager.
 #   Defaults to []
+#
+# [*delegated_pki*]
+#   Set to true if all required X509 certificates will be provided by external means. Setting this to true will ignore all *_crt and *_key variables except sa.pub and sa.key.
+#   Defaults to false
 #
 # [*kubernetes_ca_crt*]
 #   The clusters ca certificate. Must be passed as a string not a file.
@@ -427,17 +459,22 @@ class kubernetes (
   Boolean $worker                                    = false,
   Boolean $manage_docker                             = true,
   Boolean $manage_etcd                               = true,
+  Integer $kube_api_bind_port                        = 6443,
   Optional[String] $kube_api_advertise_address       = undef,
   Optional[String] $etcd_version                     = '3.2.18',
   Optional[String] $etcd_hostname                    = $facts['hostname'],
   Optional[String] $etcd_ip                          = undef,
   Optional[Array] $etcd_peers                        = undef,
   Optional[String] $etcd_initial_cluster             = undef,
+  Optional[String] $etcd_discovery_srv               = undef,
   Optional[Enum['new','existing']] $etcd_initial_cluster_state = 'new',
-  String $etcd_ca_key                                = undef,
-  String $etcd_ca_crt                                = undef,
-  String $etcdclient_key                             = undef,
-  String $etcdclient_crt                             = undef,
+  Optional[Enum['periodic','revision']] $etcd_compaction_method = 'periodic',
+  Variant[String,Integer] $etcd_compaction_retention = 0,
+  Integer $etcd_max_wals                             = 5,
+  Optional[String] $etcd_ca_key                      = undef,
+  Optional[String] $etcd_ca_crt                      = undef,
+  Optional[String] $etcdclient_key                   = undef,
+  Optional[String] $etcdclient_crt                   = undef,
   Optional[String] $etcdserver_crt                   = undef,
   Optional[String] $etcdserver_key                   = undef,
   Optional[String] $etcdpeer_crt                     = undef,
@@ -450,10 +487,11 @@ class kubernetes (
   "https://raw.githubusercontent.com/kubernetes/dashboard/${dashboard_version}/src/deploy/recommended/kubernetes-dashboard.yaml",
   Boolean $schedule_on_controller                    = false,
   Integer $api_server_count                          = undef,
-  String $kubernetes_ca_crt                          = undef,
-  String $kubernetes_ca_key                          = undef,
-  String $kubernetes_front_proxy_ca_crt              = undef,
-  String $kubernetes_front_proxy_ca_key              = undef,
+  Boolean $delegated_pki                             = false,
+  Optional[String] $kubernetes_ca_crt                = undef,
+  Optional[String] $kubernetes_ca_key                = undef,
+  Optional[String] $kubernetes_front_proxy_ca_crt    = undef,
+  Optional[String] $kubernetes_front_proxy_ca_key    = undef,
   String $token                                      = undef,
   String $ttl_duration                               = '24h',
   String $discovery_token_hash                       = undef,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -8,6 +8,7 @@ class kubernetes::packages (
   Optional[String] $docker_version             = $kubernetes::docker_version,
   Optional[String] $docker_package_name        = $kubernetes::docker_package_name,
   Optional[String] $docker_storage_driver      = $kubernetes::docker_storage_driver,
+  Optional[String] $docker_cgroup_driver       = $kubernetes::cgroup_driver,
   Optional[Array] $docker_storage_opts         = $kubernetes::docker_storage_opts,
   Optional[String] $docker_extra_daemon_config = $kubernetes::docker_extra_daemon_config,
   String $docker_log_max_file                  = $kubernetes::docker_log_max_file,

--- a/spec/classes/cluster_roles_spec.rb
+++ b/spec/classes/cluster_roles_spec.rb
@@ -15,9 +15,6 @@ describe 'kubernetes::cluster_roles', :type => :class do
         :codename => "xenial",
       },
     },
-    :networking => {
-      :hostname => 'foo',
-    },
     :ec2_metadata => {
       :hostname => 'ip-10-10-10-1.ec2.internal',
     },

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -68,6 +68,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
         'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
         'kubelet_extra_arguments' => ['foo'],
         'delegated_pki' => true,
+        'etcd_version' => '3.3.0',
       }
     end
 
@@ -89,6 +90,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--initial-cluster *}) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--auto-compaction-mode*}) }
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--discovery-srv.*}) }
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
@@ -137,12 +139,14 @@ describe 'kubernetes::config::kubeadm', :type => :class do
         'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
         'kubelet_extra_arguments' => ['foo'],
         'manage_etcd' => true,
+        'etcd_version' => '3.3.0',
       }
     end
 
     it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_AUTO_COMPACTION_MODE=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_DISCOVERY_SRV=.*}) }
   end
 
@@ -155,12 +159,14 @@ describe 'kubernetes::config::kubeadm', :type => :class do
         'kubelet_extra_arguments' => ['foo'],
         'manage_etcd' => true,
         'etcd_discovery_srv' => 'etcd-autodiscovery',
+        'etcd_version' => '2.9.9',
       }
     end
 
     it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_AUTO_COMPACTION_MODE=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_DISCOVERY_SRV="etcd-autodiscovery".*}) }
   end
 
@@ -173,6 +179,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
         'kubelet_extra_arguments' => ['foo'],
         'manage_etcd' => true,
         'etcd_discovery_srv' => 'etcd-autodiscovery',
+        'etcd_version' => '2.9.9',
       }
     end
 
@@ -180,6 +187,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--discovery-srv etcd-autodiscovery.*}) }
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--initial-cluster .*}) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--auto-compaction-mode .*}) }
   end
 
   context 'manage_etcd => true and etcd_install_method => package' do

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -51,8 +51,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     end
 
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
-    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(/.*--initial-cluster */) }
-    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(/.*--discovery-srv.*/) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--initial-cluster *}) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--discovery-srv.*}) }
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
@@ -88,8 +88,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     end
 
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
-    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(/.*--initial-cluster */) }
-    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(/.*--discovery-srv.*/) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--initial-cluster *}) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--discovery-srv.*}) }
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
@@ -142,8 +142,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/default/etcd') }
-    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
-    it { is_expected.to contain_file('/etc/default/etcd').without_content(/.*ETCD_DISCOVERY_SRV=.*/) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_DISCOVERY_SRV=.*}) }
   end
 
   context 'manage_etcd => true and etcd_install_method => package and etcd_discovery_srv => etcd-autodiscovery' do
@@ -160,8 +160,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/default/etcd') }
-    it { is_expected.to contain_file('/etc/default/etcd').without_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
-    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_DISCOVERY_SRV="etcd-autodiscovery".*/) }
+    it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_DISCOVERY_SRV="etcd-autodiscovery".*}) }
   end
 
   context 'manage_etcd => true and etcd_install_method => wget and etcd_discovery_srv => etcd-autodiscovery' do
@@ -178,8 +178,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
-    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(/.*--discovery-srv etcd-autodiscovery.*/) }
-    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(/.*--initial-cluster .*/) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--discovery-srv etcd-autodiscovery.*}) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--initial-cluster .*}) }
   end
 
   context 'manage_etcd => true and etcd_install_method => package' do
@@ -195,8 +195,8 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/default/etcd') }
-    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
-    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_DISCOVERY_SRV=.*}) }
   end
 
   context 'with version = 1.12 and node_name => foo and cloud_provider => aws' do
@@ -398,7 +398,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       {
         'kubernetes_version' => '1.14.2',
         'metrics_bind_address' => '0.0.0.0',
-        'kube_api_bind_port' => 12345,
+        'kube_api_bind_port' => 12_345,
       }
     end
 
@@ -409,7 +409,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[2]['metricsBindAddress']).to include('0.0.0.0')
     end
     it 'has 12345 in kube_api_bind_port:' do
-      expect(config_yaml[0]['localAPIEndpoint']['bindPort']).to eq(12345)
+      expect(config_yaml[0]['localAPIEndpoint']['bindPort']).to eq(12_345)
     end
   end
 
@@ -418,7 +418,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       {
         'kubernetes_version' => '1.16.3',
         'metrics_bind_address' => '0.0.0.0',
-        'kube_api_bind_port' => 12345,
+        'kube_api_bind_port' => 12_345,
       }
     end
 
@@ -429,7 +429,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[2]['metricsBindAddress']).to include('0.0.0.0')
     end
     it 'has 12345 in kube_api_bind_port:' do
-      expect(config_yaml[0]['localAPIEndpoint']['bindPort']).to eq(12345)
+      expect(config_yaml[0]['localAPIEndpoint']['bindPort']).to eq(12_345)
     end
   end
 

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -51,6 +51,45 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     end
 
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(/.*--initial-cluster */) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(/.*--discovery-srv.*/) }
+    it { is_expected.not_to contain_file('/etc/default/etcd') }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo}) }
+  end
+
+  context 'with manage_etcd => true and delegated_pki => true' do
+    let(:pre_condition) { 'include kubernetes' }
+    let(:params) do
+      {
+        'manage_etcd' => true,
+        'kubeadm_extra_config' => { 'foo' => ['bar', 'baz'] },
+        'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
+        'kubelet_extra_arguments' => ['foo'],
+        'delegated_pki' => true,
+      }
+    end
+
+    kube_dirs = ['/etc/kubernetes', '/etc/kubernetes/manifests', '/etc/kubernetes/pki', '/etc/kubernetes/pki/etcd']
+    etcd = ['ca.crt', 'ca.key', 'client.crt', 'client.key', 'peer.crt', 'peer.key', 'server.crt', 'server.key']
+    pki = ['ca.crt', 'ca.key', 'front-proxy-ca.crt', 'front-proxy-ca.key', 'sa.pub', 'sa.key']
+
+    kube_dirs.each do |d|
+      it { is_expected.to contain_file(d.to_s) }
+    end
+
+    etcd.each do |f|
+      it { is_expected.not_to contain_file("/etc/kubernetes/pki/etcd/#{f}") }
+    end
+
+    pki.each do |cert|
+      it { is_expected.not_to contain_file("/etc/kubernetes/pki/#{cert}") }
+    end
+
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(/.*--initial-cluster */) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(/.*--discovery-srv.*/) }
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
@@ -103,6 +142,61 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
     it { is_expected.to contain_file('/etc/default/etcd') }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
+    it { is_expected.to contain_file('/etc/default/etcd').without_content(/.*ETCD_DISCOVERY_SRV=.*/) }
+  end
+
+  context 'manage_etcd => true and etcd_install_method => package and etcd_discovery_srv => etcd-autodiscovery' do
+    let(:params) do
+      {
+        'etcd_install_method' => 'package',
+        'kubeadm_extra_config' => { 'foo' => ['bar', 'baz'] },
+        'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
+        'kubelet_extra_arguments' => ['foo'],
+        'manage_etcd' => true,
+        'etcd_discovery_srv' => 'etcd-autodiscovery',
+      }
+    end
+
+    it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
+    it { is_expected.to contain_file('/etc/default/etcd') }
+    it { is_expected.to contain_file('/etc/default/etcd').without_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_DISCOVERY_SRV="etcd-autodiscovery".*/) }
+  end
+
+  context 'manage_etcd => true and etcd_install_method => wget and etcd_discovery_srv => etcd-autodiscovery' do
+    let(:params) do
+      {
+        'etcd_install_method' => 'wget',
+        'kubeadm_extra_config' => { 'foo' => ['bar', 'baz'] },
+        'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
+        'kubelet_extra_arguments' => ['foo'],
+        'manage_etcd' => true,
+        'etcd_discovery_srv' => 'etcd-autodiscovery',
+      }
+    end
+
+    it { is_expected.not_to contain_file('/etc/default/etcd') }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service') }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(/.*--discovery-srv etcd-autodiscovery.*/) }
+    it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(/.*--initial-cluster .*/) }
+  end
+
+  context 'manage_etcd => true and etcd_install_method => package' do
+    let(:params) do
+      {
+        'etcd_install_method' => 'package',
+        'kubeadm_extra_config' => { 'foo' => ['bar', 'baz'] },
+        'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
+        'kubelet_extra_arguments' => ['foo'],
+        'manage_etcd' => true,
+      }
+    end
+
+    it { is_expected.not_to contain_file('/etc/systemd/system/etcd.service') }
+    it { is_expected.to contain_file('/etc/default/etcd') }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(/.*ETCD_INITIAL_CLUSTER=.*/) }
   end
 
   context 'with version = 1.12 and node_name => foo and cloud_provider => aws' do
@@ -299,11 +393,12 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     end
   end
 
-  context 'with metrics_bind_address = 0.0.0.0 with version 1.14.2' do
+  context 'with metrics_bind_address = 0.0.0.0 with version 1.14.2 and kube_api_bind_port 12345' do
     let(:params) do
       {
         'kubernetes_version' => '1.14.2',
         'metrics_bind_address' => '0.0.0.0',
+        'kube_api_bind_port' => 12345,
       }
     end
 
@@ -313,13 +408,17 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it 'has 0.0.0.0 in metrics_bind_address:' do
       expect(config_yaml[2]['metricsBindAddress']).to include('0.0.0.0')
     end
+    it 'has 12345 in kube_api_bind_port:' do
+      expect(config_yaml[0]['localAPIEndpoint']['bindPort']).to eq(12345)
+    end
   end
 
-  context 'with metrics_bind_address = 0.0.0.0 with version 1.16.3' do
+  context 'with metrics_bind_address = 0.0.0.0 with version 1.16.3 and kube_api_bind_port 12345' do
     let(:params) do
       {
         'kubernetes_version' => '1.16.3',
         'metrics_bind_address' => '0.0.0.0',
+        'kube_api_bind_port' => 12345,
       }
     end
 
@@ -328,6 +427,9 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it 'has 0.0.0.0 in metrics_bind_address:' do
       expect(config_yaml[2]['metricsBindAddress']).to include('0.0.0.0')
+    end
+    it 'has 12345 in kube_api_bind_port:' do
+      expect(config_yaml[0]['localAPIEndpoint']['bindPort']).to eq(12345)
     end
   end
 

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -32,9 +32,10 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
-	'docker_storage_driver' => 'overlay2',
-	'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
         'docker_extra_daemon_config' => '',
+        'docker_cgroup_driver' => 'systemd',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -62,7 +63,16 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-opts"\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_removal=true",\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
     it { should contain_file('/etc/systemd/system/docker.service.d')}
+    it '/etc/docker/daemon.json should be valid JSON' do
+      require 'json'
+      json_data = catalogue
+        .resource('file', '/etc/docker/daemon.json')
+        .send(:parameters)[:content]
+      puts json_data
+      expect { JSON.parse(json_data) }.to_not raise_error
+    end
   end
 
   context 'with osfamily => RedHat and container_runtime => Docker and manage_docker => true and manage_etcd => true and etcd_install_method => package' do
@@ -97,9 +107,10 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
-	'docker_storage_driver' => 'overlay2',
-	'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
-        'docker_extra_daemon_config' => 'dummy',
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
+        'docker_extra_daemon_config' => '"dummy": "dummy"',
+        'docker_cgroup_driver' => 'cgroupfs',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -123,12 +134,20 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubectl').with_ensure('1.10.2')}
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
     it { should contain_file('/etc/docker')}
-    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*dummy\s*/)}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dummy": "dummy"\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-driver": "overlay2",\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-opts"\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_removal=true",\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=cgroupfs"\s*/)}
     it { should contain_file('/etc/systemd/system/docker.service.d')}
+    it '/etc/docker/daemon.json should be valid JSON' do
+      require 'json'
+      json_data = catalogue
+        .resource('file', '/etc/docker/daemon.json')
+        .send(:parameters)[:content]
+      expect { JSON.parse(json_data) }.to_not raise_error
+    end
   end
 
   context 'with osfamily => Debian and container_runtime => cri_containerd and manage_etcd => false' do
@@ -166,9 +185,10 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
-	'docker_storage_driver' => 'overlay2',
-	'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
         'docker_extra_daemon_config' => '',
+        'docker_cgroup_driver' => 'systemd',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => false,
@@ -198,7 +218,84 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-opts"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_removal=true",\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
+    it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
+  end
+
+  context 'with osfamily => Debian and container_runtime => Docker and manage_docker => true and manage_etcd => true' do
+    let(:facts) do
+      {
+        :osfamily         => 'Debian', #needed to run dependent tests from fixtures camptocamp-kmod
+        :kernel           => 'Linux',
+        :os               => {
+          :family => "Debian",
+          :name    => 'Ubuntu',
+          :release => {
+            :full => '16.04',
+          },
+          :distro => {
+            :codename => "xenial",
+          },
+        },
+      }
+    end
+    let(:pre_condition) {
+       '
+       include apt
+       exec { \'kubernetes-systemd-reload\': }
+       service { \'docker\': }
+       '
+    }
+
+    let(:params) do
+        {
+        'container_runtime' => 'docker',
+        'kubernetes_package_version' => '1.10.2',
+        'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
+        'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
+        'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
+        'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
+        'runc_source' => 'https://github.com/runcsource',
+        'controller' => true,
+        'docker_package_name' => 'docker-engine',
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => [],
+        'docker_extra_daemon_config' => '"default-runtime": "runc"',
+        'docker_cgroup_driver' => 'systemd',
+        'disable_swap' => true,
+        'manage_docker' => true,
+        'manage_etcd' => true,
+        'manage_kernel_modules' => true,
+        'manage_sysctl_settings' => true,
+        'etcd_install_method' => 'wget',
+        'etcd_package_name' => 'etcd-server',
+        'etcd_version' => '3.1.12',
+        'create_repos' => true,
+        'docker_log_max_file' => '1',
+        'docker_log_max_size' => '100m',
+        }
+    end
+    it { should contain_kmod__load('br_netfilter')}
+    it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
+    it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
+    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should contain_package('kubelet').with_ensure('1.10.2')}
+    it { should contain_package('kubectl').with_ensure('1.10.2')}
+    it { should contain_package('kubeadm').with_ensure('1.10.2')}
+    it { should contain_package('docker-engine').with_ensure('17.03.0~ce-0~ubuntu-xenial')}
+    it { should contain_file('/etc/docker')}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"default-runtime": "runc"\s*/)}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-driver": "overlay2",\s*/)}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-opts"\s*/)}
+    it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
+    it '/etc/docker/daemon.json should be valid JSON' do
+      require 'json'
+      json_data = catalogue
+        .resource('file', '/etc/docker/daemon.json')
+        .send(:parameters)[:content]
+      expect { JSON.parse(json_data) }.to_not raise_error
+    end
   end
 
   context 'with osfamily => Debian and container_runtime => Docker and manage_docker => false and manage_etcd => true' do
@@ -237,9 +334,10 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
-	'docker_storage_driver' => 'overlay2',
-	'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
         'docker_extra_daemon_config' => '"default-runtime": "runc"',
+        'docker_cgroup_driver' => 'systemd',
         'disable_swap' => true,
         'manage_docker' => false,
         'manage_etcd' => true,
@@ -267,7 +365,7 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-opts"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_removal=true",\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
-    it { should_not contain_file('/etc/systemd/system/docker.service.d')}
+    it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
   end
 
   context 'with disable_swap => true' do
@@ -305,9 +403,10 @@ describe 'kubernetes::packages', :type => :class do
         'runc_source' => 'https://github.com/runcsource',
         'controller' => true,
         'docker_package_name' => 'docker-engine',
-	'docker_storage_driver' => 'overlay2',
-	'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
         'docker_extra_daemon_config' => '"default-runtime": "runc"',
+        'docker_cgroup_driver' => 'systemd',
         'disable_swap' => true,
         'manage_docker' => true,
         'manage_etcd' => true,
@@ -331,6 +430,7 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_removal=true",\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"default-runtime": "runc"\s*/)}
+    it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
   end
 end

--- a/spec/defines/kubeadm_init_spec.rb
+++ b/spec/defines/kubeadm_init_spec.rb
@@ -32,4 +32,34 @@ describe 'kubernetes::kubeadm_init', :type => :define do
     it { is_expected.to contain_exec('kubeadm init').with_command("kubeadm init --config '/etc/kubernetes/config.yaml'")}
     it { is_expected.to contain_kubernetes__wait_for_default_sa('default')}
   end
+
+  context 'with dry_run => true' do
+    let(:params) do
+      {
+        'config' => '/etc/kubernetes/config.yaml',
+        'node_name' => 'kube-master',
+        'path' => [ '/bin','/usr/bin','/sbin'],
+        'dry_run' => true,
+        'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+      }
+    end
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm init').with_command("kubeadm init --config '/etc/kubernetes/config.yaml' --dry-run")}
+    it { is_expected.to contain_kubernetes__wait_for_default_sa('default')}
+  end
+
+  context 'with ignore_preflight => [foo, bar]' do
+    let(:params) do
+      {
+        'config' => '/etc/kubernetes/config.yaml',
+        'node_name' => 'kube-master',
+        'path' => [ '/bin','/usr/bin','/sbin'],
+        'ignore_preflight_errors' => ['foo', 'bar'],
+        'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+      }
+    end
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm init').with_command("kubeadm init --config '/etc/kubernetes/config.yaml' --ignore-preflight-errors='foo,bar'")}
+    it { is_expected.to contain_kubernetes__wait_for_default_sa('default')}
+  end
 end

--- a/spec/defines/kubeadm_join_spec.rb
+++ b/spec/defines/kubeadm_join_spec.rb
@@ -50,4 +50,28 @@ describe 'kubernetes::kubeadm_join', :type => :define do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_exec('kubeadm join').with_command("kubeadm join --config '/etc/kubernetes/config.yaml'")}
   end
+
+  context 'with kubernetes_version => 1.12.3 and ignore_preflight_errors => [foo, bar]' do
+    let(:params) do
+      super().merge({
+        :kubernetes_version => '1.12.3',
+        :ignore_preflight_errors => ['foo', 'bar'],
+      })
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm join').with_command("kubeadm join --config '/etc/kubernetes/config.yaml' --ignore-preflight-errors 'foo,bar'")}
+  end
+
+  context 'with kubernetes_version => 1.12.3 and discovery_file => /etc/kubernetes/admin.conf' do
+    let(:params) do
+      super().merge({
+        :kubernetes_version => '1.12.3',
+        :discovery_file => '/etc/kubernetes/admin.conf',
+      })
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec('kubeadm join').with_command("kubeadm join --discovery-file '/etc/kubernetes/admin.conf'")}
+  end
 end

--- a/templates/docker/daemon_debian.json.erb
+++ b/templates/docker/daemon_debian.json.erb
@@ -5,7 +5,7 @@
     "max-size": "<%= @docker_log_max_size %>",
     "max-file": "<%= @docker_log_max_file %>"
   },
-  <%- if @docker_extra_daemon_config -%>
+  <%- if @docker_extra_daemon_config and @docker_extra_daemon_config != '' -%>
   <%= @docker_extra_daemon_config -%>,
   <%- end -%>
   "storage-driver": "<%= @docker_storage_driver %>"<%= "," if @docker_storage_opts %>

--- a/templates/docker/daemon_debian.json.erb
+++ b/templates/docker/daemon_debian.json.erb
@@ -1,5 +1,5 @@
 {
-  "exec-opts": ["native.cgroupdriver=systemd"],
+  "exec-opts": ["native.cgroupdriver=<%= @docker_cgroup_driver %>"],
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "<%= @docker_log_max_size %>",
@@ -8,10 +8,10 @@
   <%- if @docker_extra_daemon_config -%>
   <%= @docker_extra_daemon_config -%>,
   <%- end -%>
-  "storage-driver": "<%= @docker_storage_driver %>",
+  "storage-driver": "<%= @docker_storage_driver %>"<%= "," if @docker_storage_opts %>
   <%- if @docker_storage_opts -%>
   "storage-opts": [
-  <%- @docker_storage_opts.each do |opt| -%> 
+  <%- @docker_storage_opts.each do |opt| -%>
     "<%= opt %>"<%= "," if opt != @docker_storage_opts.last %>
   <%- end -%>
   ]

--- a/templates/docker/daemon_redhat.json.erb
+++ b/templates/docker/daemon_redhat.json.erb
@@ -5,7 +5,7 @@
     "max-size": "<%= @docker_log_max_size %>",
     "max-file": "<%= @docker_log_max_file %>"
   },
-  <%- if @docker_extra_daemon_config -%>
+  <%- if @docker_extra_daemon_config and @docker_extra_daemon_config != '' -%>
   <%= @docker_extra_daemon_config -%>,
   <%- end -%>
   "storage-driver": "<%= @docker_storage_driver %>"<%= "," if @docker_storage_opts %>

--- a/templates/docker/daemon_redhat.json.erb
+++ b/templates/docker/daemon_redhat.json.erb
@@ -1,5 +1,5 @@
 {
-  "exec-opts": ["native.cgroupdriver=systemd"],
+  "exec-opts": ["native.cgroupdriver=<%= @docker_cgroup_driver %>"],
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "<%= @docker_log_max_size %>",
@@ -8,10 +8,10 @@
   <%- if @docker_extra_daemon_config -%>
   <%= @docker_extra_daemon_config -%>,
   <%- end -%>
-  "storage-driver": "<%= @docker_storage_driver %>",
+  "storage-driver": "<%= @docker_storage_driver %>"<%= "," if @docker_storage_opts %>
   <%- if @docker_storage_opts -%>
   "storage-opts": [
-  <%- @docker_storage_opts.each do |opt| -%> 
+  <%- @docker_storage_opts.each do |opt| -%>
     "<%= opt %>"<%= "," if opt != @docker_storage_opts.last %>
   <%- end -%>
   ]

--- a/templates/etcd/etcd.erb
+++ b/templates/etcd/etcd.erb
@@ -11,7 +11,9 @@ ETCD_INITIAL_CLUSTER="<%= @etcd_initial_cluster %>"
 <% end -%>
 ETCD_INITIAL_CLUSTER_STATE="new"
 ETCD_INITIAL_CLUSTER_TOKEN="my-etcd-token"
+<% if @etcd_version >= "3.3.0" -%>
 ETCD_AUTO_COMPACTION_MODE="<%= @etcd_compaction_method %>"
+<% end -%>
 ETCD_AUTO_COMPACTION_RETENTION="<%= @etcd_compaction_retention %>"
 ETCD_MAX_WALS="<%= @etcd_max_wals %>"
 ETCD_ADVERTISE_CLIENT_URLS="https://<%= @etcd_ip %>:2379"

--- a/templates/etcd/etcd.erb
+++ b/templates/etcd/etcd.erb
@@ -2,10 +2,18 @@ ETCD_NAME="<%= @hostname %>"
 ETCD_DATA_DIR="/var/lib/etcd"
 ETCD_LISTEN_PEER_URLS="https://<%= @etcd_ip %>:2380"
 ETCD_LISTEN_CLIENT_URLS="https://<%= @etcd_ip %>:2379"
+<% if @etcd_discovery_srv -%>
+ETCD_DISCOVERY_SRV="<%= @etcd_discovery_srv %>"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://<%= @etcd_hostname %>:2380"
+<% else -%>
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://<%= @etcd_ip %>:2380"
 ETCD_INITIAL_CLUSTER="<%= @etcd_initial_cluster %>"
+<% end -%>
 ETCD_INITIAL_CLUSTER_STATE="new"
 ETCD_INITIAL_CLUSTER_TOKEN="my-etcd-token"
+ETCD_AUTO_COMPACTION_MODE="<%= @etcd_compaction_method %>"
+ETCD_AUTO_COMPACTION_RETENTION="<%= @etcd_compaction_retention %>"
+ETCD_MAX_WALS="<%= @etcd_max_wals %>"
 ETCD_ADVERTISE_CLIENT_URLS="https://<%= @etcd_ip %>:2379"
 ETCD_CERT_FILE="/etc/kubernetes/pki/etcd/server.crt"
 ETCD_KEY_FILE="/etc/kubernetes/pki/etcd/server.key"

--- a/templates/etcd/etcd.service.erb
+++ b/templates/etcd/etcd.service.erb
@@ -16,7 +16,11 @@ ExecStart=/usr/local/bin/etcd --name <%= @etcd_hostname %> \
     --listen-client-urls https://<%= @etcd_ip %>:2379 \
     --advertise-client-urls https://<%= @etcd_ip %>:2379 \
     --listen-peer-urls https://<%= @etcd_ip %>:2380 \
+<% if @etcd_discovery_srv -%>
+    --initial-advertise-peer-urls https://<%= @etcd_hostname %>:2380 \
+<% else -%>
     --initial-advertise-peer-urls https://<%= @etcd_ip %>:2380 \
+<% end -%>
     --cert-file=/etc/kubernetes/pki/etcd/server.crt \
     --key-file=/etc/kubernetes/pki/etcd/server.key \
     --client-cert-auth \
@@ -25,9 +29,17 @@ ExecStart=/usr/local/bin/etcd --name <%= @etcd_hostname %> \
     --peer-key-file=/etc/kubernetes/pki/etcd/peer.key \
     --peer-client-cert-auth \
     --peer-trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt \
+<% if @etcd_discovery_srv -%>
+    --discovery-srv <%= @etcd_discovery_srv %> \
+<% else -%>
     --initial-cluster <%= @etcd_initial_cluster %> \
+<% end -%>
     --initial-cluster-token my-etcd-token \
-    --initial-cluster-state <%= @etcd_initial_cluster_state %>
+    --initial-cluster-state <%= @etcd_initial_cluster_state %> \
+    --auto-compaction-retention <%= @etcd_compaction_retention %> \
+    --auto-compaction-mode <%= @etcd_compaction_method %> \
+    --max-wals <%= @etcd_max_wals %>
+
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etcd/etcd.service.erb
+++ b/templates/etcd/etcd.service.erb
@@ -37,7 +37,9 @@ ExecStart=/usr/local/bin/etcd --name <%= @etcd_hostname %> \
     --initial-cluster-token my-etcd-token \
     --initial-cluster-state <%= @etcd_initial_cluster_state %> \
     --auto-compaction-retention <%= @etcd_compaction_retention %> \
+<% if @etcd_version >= "3.3.0" -%>
     --auto-compaction-mode <%= @etcd_compaction_method %> \
+<% end -%>
     --max-wals <%= @etcd_max_wals %>
 
 

--- a/templates/v1alpha3/config_kubeadm.yaml.erb
+++ b/templates/v1alpha3/config_kubeadm.yaml.erb
@@ -1,7 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1alpha3
 apiEndpoint:
   advertiseAddress: <%= @kube_api_advertise_address %>
-  bindPort: 6443
+  bindPort: <%= @kube_api_bind_port %>
 bootstrapTokens:
   - token: "<%= @token %>"
     description: "kubeadm bootstrap token"

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -11,7 +11,7 @@ bootstrapTokens:
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: <%= @kube_api_advertise_address %>
-  bindPort: 6443
+  bindPort: <%= @kube_api_bind_port %>
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -10,7 +10,7 @@ bootstrapTokens:
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: <%= @kube_api_advertise_address %>
-  bindPort: 6443
+  bindPort: <%= @kube_api_bind_port %>
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -134,4 +134,5 @@ mode: "<%= @proxy_mode %>"
 nodePortAddresses: null
 oomScoreAdj: -999
 portRange: ""
+resourceContainer: /
 udpIdleTimeout: 250ms


### PR DESCRIPTION
This PR is the result of adapting the module to be used to replace a kubespray based deployment for a k8s 1.15.3 version.
The main relevant changes in the PR are the following:
* Add a `delegated_pki` option. If set to `true`, all the required x509 certificates under `/etc/kubernetes/pki/` must be provided externally by the module user by other means. We added that option as we are providing all certificates (including `sa.pub` and `sa.key`) from a Hashicorp Vault server dinamically instead of the ones generated by `kubetool`.
* Fix docker `daemon.json` templates. 
    * Respect `docker_cgroup_driver` variable for `/etc/docker/daemon.json` generated file.
    * Don't add extra `,` when `docker_storage_opts` is empty.
    * Don't add extra `,` when `docker_extra_daemon_config` is an empty string
    * Added spec cases to verify that generated `daemon.json` file is actually a JSON valid file.
* Added extra options to `etcd`:
    * Add `discovery_srv` method (https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/clustering.md#dns-discovery). If `etcd_discovery_srv` variable is set and not empty then take precedence over `etcd_initial_cluster` setting.
    * Add `etcd_compaction_method`, `etcd_compaction_retention` and `etcd_max_wals` settings for etcd servers.
* Add `join_discovery_file` variable to `kubernetes` class.
    * Used to be passed to `kubeadm join` to use a `--discovery-file` instead of `--config` parameters. This is needed when certificates are provided externally.
* Add `kube_api_bind_port` variable `kubernetes` class. Used to override default port for `bindPort` for `InitConfiguration` in `/etc/kubernetes/config.yaml`
* Use `v1beta2` kubeadm configuration version for kubernetes 1.15.3+. (Probably can be used for all 1.15 versions).
* Add some additional test cases to cover new variables.