### PR TITLE
improve initial installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         ruby_version: [2.5.x]
         puppet_gem_version: [~> 6.0]
         platform: [release_checks]
-        agent_family: ['puppet5', 'puppet6-nightly']
+        agent_family: ['puppet5', 'puppet6']
 
     steps:
     - uses: actions/checkout@v1
@@ -30,7 +30,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        check: [parallel_spec, 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop']
+        check: [spec, 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop']
         ruby_version: [2.5.x]
         puppet_gem_version: [~> 5.0, ~> 6.0]
         exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v5.2.0](https://github.com/puppetlabs/puppetlabs-kubernetes/tree/v5.2.0) (2020-05-13)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-kubernetes/compare/v5.1.0...v5.2.0)
+
+### Added
+
+- \(FEAT\) Add docker storage options [\#383](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/383) ([AblionGE](https://github.com/AblionGE))
+
+### Fixed
+
+- Create client certificates per server with SAN values [\#382](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/382) ([AblionGE](https://github.com/AblionGE))
+
 ## [v5.1.0](https://github.com/puppetlabs/puppetlabs-kubernetes/tree/v5.1.0) (2020-01-27)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-kubernetes/compare/v5.0.0...v5.1.0)
@@ -52,6 +64,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Add extra arguments for API server and controller manager [\#282](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/282) ([fydai](https://github.com/fydai))
 - cluster name missing tag brackets in worker config [\#280](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/280) ([jorhett](https://github.com/jorhett))
 - Avoid log message about waiting for SA when it already exists [\#278](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/278) ([jorhett](https://github.com/jorhett))
 - MODULES-8947 fixing bugs and tests [\#274](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/274) ([sheenaajay](https://github.com/sheenaajay))

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -905,6 +905,14 @@ Defaults to ""
  The URL for the Docker yum repo gpg key
  Defaults to https://yum.dockerproject.org/gpg
 
+[*docker_storage_driver*]
+ Storage Driver to be added to `/etc/docker/daemon.json`
+ Defaults to overlay2
+
+[*docker_storage_opts*]
+ Storage options to be added to `/etc/docker/daemon.json`
+ Defaults to undef
+
 [*docker_extra_daemon_config*]
  Extra configuration to be added to `/etc/docker/daemon.json`
  Defaults to undef
@@ -1473,7 +1481,7 @@ Data type: `String`
 
 
 
-Default value: "https://github.com/coreos/etcd/releases/download/v${etcd_version}/${etcd_archive}"
+Default value: "https://github.com/etcd-io/etcd/releases/download/v${etcd_version}/${etcd_archive}"
 
 ##### `etcd_install_method`
 
@@ -1594,6 +1602,22 @@ Data type: `Optional[String]`
 
 
 Default value: `undef`
+
+##### `docker_storage_driver`
+
+Data type: `Optional[String]`
+
+
+
+Default value: 'overlay2'
+
+##### `docker_storage_opts`
+
+Data type: `Optional[Array]`
+
+
+
+Default value: $facts['os']['family']
 
 ##### `docker_extra_daemon_config`
 
@@ -2466,6 +2490,22 @@ Data type: `Optional[String]`
 
 
 Default value: $kubernetes::docker_package_name
+
+##### `docker_storage_driver`
+
+Data type: `Optional[String]`
+
+
+
+Default value: $kubernetes::docker_storage_driver
+
+##### `docker_storage_opts`
+
+Data type: `Optional[Array]`
+
+
+
+Default value: $kubernetes::docker_storage_opts
 
 ##### `docker_extra_daemon_config`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -315,6 +315,11 @@
 # The mode for kubeproxy to run. It should be one of: "" (default), "userspace", "kernelspace", "iptables", or "ipvs".
 # Defaults to ""
 #
+# [*pin_packages*]
+#  Enable pinning of the docker and kubernetes packages to prevent accidential updates.
+#  This is currently only implemented for debian based distributions.
+#  Defaults to false
+#
 # [*kubernetes_apt_location*]
 #  The APT repo URL for the Kubernetes packages.
 #  Defaults to https://apt.kubernetes.io
@@ -449,6 +454,7 @@ class kubernetes (
                                                           'Debian' => '17.03.0~ce-0~ubuntu-xenial',
                                                           'RedHat' => '17.03.1.ce-1.el7.centos',
                                                         },
+  Boolean $pin_packages                              = false,
   Optional[String] $dns_domain                       = 'cluster.local',
   Optional[String] $cni_pod_cidr                     = undef,
   Boolean $controller                                = false,
@@ -544,7 +550,7 @@ class kubernetes (
   Boolean $manage_sysctl_settings                    = true,
   Boolean $create_repos                              = true,
   String $image_repository                           = 'k8s.gcr.io',
-  Array[String] $default_path                        = ['/usr/bin','/bin','/sbin','/usr/local/bin'],
+  Array[String] $default_path                        = ['/usr/bin','/usr/sbin','/bin','/sbin','/usr/local/bin'],
   String $cgroup_driver                              = $facts['os']['family'] ? {
                                                           'RedHat' => 'systemd',
                                                           default  => 'cgroupfs',

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -1,18 +1,18 @@
 # Class kubernetes kube_addons
 class kubernetes::kube_addons (
 
-  Optional[String] $cni_network_provider     = $kubernetes::cni_network_provider,
-  Optional[String] $cni_rbac_binding         = $kubernetes::cni_rbac_binding,
-  Boolean $install_dashboard                 = $kubernetes::install_dashboard,
-  String $dashboard_version                  = $kubernetes::dashboard_version,
-  String $kubernetes_version                 = $kubernetes::kubernetes_version,
-  String $kubernetes_dashboard_url           = $kubernetes::kubernetes_dashboard_url,
-  Boolean $controller                        = $kubernetes::controller,
-  Optional[Boolean] $schedule_on_controller  = $kubernetes::schedule_on_controller,
-  String $node_name                          = $kubernetes::node_name,
-  Array $path                                = $kubernetes::default_path,
-  Optional[Array] $env                       = $kubernetes::environment,
-){
+  Optional[String] $cni_network_provider    = $kubernetes::cni_network_provider,
+  Optional[String] $cni_rbac_binding        = $kubernetes::cni_rbac_binding,
+  Boolean $install_dashboard                = $kubernetes::install_dashboard,
+  String $dashboard_version                 = $kubernetes::dashboard_version,
+  String $kubernetes_version                = $kubernetes::kubernetes_version,
+  String $kubernetes_dashboard_url          = $kubernetes::kubernetes_dashboard_url,
+  Boolean $controller                       = $kubernetes::controller,
+  Optional[Boolean] $schedule_on_controller = $kubernetes::schedule_on_controller,
+  String $node_name                         = $kubernetes::node_name,
+  Array $path                               = $kubernetes::default_path,
+  Optional[Array] $env                      = $kubernetes::environment,
+) {
 
   Exec {
     path        => $path,
@@ -20,15 +20,15 @@ class kubernetes::kube_addons (
     logoutput   => true,
     tries       => 10,
     try_sleep   => 30,
-    }
+  }
 
   if $cni_rbac_binding {
     $shellsafe_binding = shell_escape($cni_rbac_binding)
     exec { 'Install calico rbac bindings':
-    environment => $env,
-    command     => "kubectl apply -f ${shellsafe_binding}",
-    onlyif      => 'kubectl get nodes',
-    unless      => 'kubectl get clusterrole | grep calico'
+      environment => $env,
+      command     => "kubectl apply -f ${shellsafe_binding}",
+      onlyif      => 'kubectl get nodes',
+      unless      => 'kubectl get clusterrole | grep calico'
     }
   }
 
@@ -50,13 +50,16 @@ class kubernetes::kube_addons (
     }
   }
 
-  if $install_dashboard  {
+  if $install_dashboard {
     $shellsafe_source = shell_escape($kubernetes_dashboard_url)
     exec { 'Install Kubernetes dashboard':
       command     => "kubectl apply -f ${shellsafe_source}",
       onlyif      => 'kubectl get nodes',
-      unless      => 'kubectl -n kube-system get pods | grep kubernetes-dashboard',
+      unless      => [
+        'kubectl get pods --field-selector="status.phase=Running" -n kubernetes-dashboard|grep kubernetes-dashboard-',
+        'kubectl get pods --field-selector="status.phase=Running" -n kube-system|grep kubernetes-dashboard-',
+      ],
       environment => $env,
-      }
     }
+  }
 }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -26,6 +26,8 @@ class kubernetes::packages (
   Boolean $manage_kernel_modules               = $kubernetes::manage_kernel_modules,
   Boolean $manage_sysctl_settings              = $kubernetes::manage_sysctl_settings,
   Boolean $create_repos                        = $kubernetes::repos::create_repos,
+  Boolean $pin_packages                        = $kubernetes::pin_packages,
+  Integer $package_pin_priority                = 32767,
 ) {
 
 
@@ -78,10 +80,25 @@ class kubernetes::packages (
             ensure  => $docker_version,
             require => Class['Apt::Update'],
           }
-        }
-        else {
+          if $pin_packages {
+            file { '/etc/apt/preferences.d/docker':
+              mode    => '0444',
+              owner   => 'root',
+              group   => 'root',
+              content => template('kubernetes/docker_apt_package_pins.erb'),
+              notify  => Service['docker'],
+            }
+          }else {
+            file { '/etc/apt/preferences.d/docker':
+              ensure => absent,
+            }
+          }
+        }else {
           package { $docker_package_name:
             ensure => $docker_version,
+          }
+          if $pin_packages {
+            fail('for safety reasons package pinning is only usable if you define the create_repos and manage_docker flags')
           }
         }
 
@@ -179,13 +196,28 @@ class kubernetes::packages (
   }
 
   if $create_repos and $facts['os']['family'] == 'Debian' {
-        package { $kube_packages:
-          ensure  => $kubernetes_package_version,
-          require => Class['Apt::Update'],
-        }
+    package { $kube_packages:
+      ensure  => $kubernetes_package_version,
+      require => Class['Apt::Update'],
+    }
+    if $pin_packages {
+      file { '/etc/apt/preferences.d/kubernetes':
+        mode    => '0444',
+        owner   => 'root',
+        group   => 'root',
+        content => template('kubernetes/kubernetes_apt_package_pins.erb'),
+      }
+    }else {
+      file { '/etc/apt/preferences.d/kubernetes':
+        ensure => absent,
+      }
+    }
   }else {
     package { $kube_packages:
       ensure => $kubernetes_package_version,
+    }
+    if $pin_packages {
+      fail('package pinning is not implemented on this platform')
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-kubernetes",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "author": "Puppet",
   "summary": "The module installs and configures a Kubernetes cluster",
   "license": "Apache-2.0",

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 describe 'kubernetes::packages', :type => :class do
+  let(:pre_condition) do
+      [
+      'include kubernetes',
+      'include kubernetes::config::kubeadm',
+      'exec { \'kubernetes-systemd-reload\': }',
+      'archive{ \'etcd-archive\': }',
+      ]
+  end
   context 'with osfamily => RedHat and container_runtime => Docker and manage_docker => true and manage_etcd => true' do
     let(:facts) do
       {
@@ -47,6 +55,7 @@ describe 'kubernetes::packages', :type => :class do
         'create_repos' => true,
         'docker_log_max_file' => '1',
         'docker_log_max_size' => '100m',
+        'pin_packages'  => false,
         }
     end
     it { should contain_kmod__load('br_netfilter')}
@@ -65,6 +74,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
     it { should contain_file('/etc/systemd/system/docker.service.d')}
+    it { should_not contain_file('/etc/apt/preferences.d/docker')}
+    it { should_not contain_file('/etc/apt/preferences.d/kubernetes')}
     it '/etc/docker/daemon.json should be valid JSON' do
       require 'json'
       json_data = catalogue
@@ -122,6 +133,7 @@ describe 'kubernetes::packages', :type => :class do
         'create_repos' => true,
         'docker_log_max_file' => '1',
         'docker_log_max_size' => '100m',
+        'pin_packages'  => false,
         }
     end
     it { should contain_kmod__load('br_netfilter')}
@@ -141,6 +153,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=cgroupfs"\s*/)}
     it { should contain_file('/etc/systemd/system/docker.service.d')}
+    it { should_not contain_file('/etc/apt/preferences.d/docker')}
+    it { should_not contain_file('/etc/apt/preferences.d/kubernetes')}
     it '/etc/docker/daemon.json should be valid JSON' do
       require 'json'
       json_data = catalogue
@@ -200,6 +214,7 @@ describe 'kubernetes::packages', :type => :class do
         'create_repos' => true,
         'docker_log_max_file' => '1',
         'docker_log_max_size' => '100m',
+        'pin_packages' => true,
         }
     end
     it { should contain_kmod__load('br_netfilter')}
@@ -220,6 +235,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
+    it { should_not contain_file('/etc/apt/preferences.d/docker')}
+    it { should contain_file('/etc/apt/preferences.d/kubernetes')}
   end
 
   context 'with osfamily => Debian and container_runtime => Docker and manage_docker => true and manage_etcd => true' do
@@ -274,6 +291,7 @@ describe 'kubernetes::packages', :type => :class do
         'create_repos' => true,
         'docker_log_max_file' => '1',
         'docker_log_max_size' => '100m',
+        'pin_packages'  => true,
         }
     end
     it { should contain_kmod__load('br_netfilter')}
@@ -289,6 +307,7 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-driver": "overlay2",\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"storage-opts"\s*/)}
     it { should contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
+    it { should contain_file('/etc/apt/preferences.d/docker')}
     it '/etc/docker/daemon.json should be valid JSON' do
       require 'json'
       json_data = catalogue
@@ -349,6 +368,7 @@ describe 'kubernetes::packages', :type => :class do
         'create_repos' => true,
         'docker_log_max_file' => '1',
         'docker_log_max_size' => '100m',
+        'pin_packages' => false,
         }
     end
     it { should contain_kmod__load('br_netfilter')}
@@ -366,6 +386,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_removal=true",\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
+    it { should_not contain_file('/etc/apt/preferences.d/docker')}
+    it { should contain_file('/etc/apt/preferences.d/kubernetes')}
   end
 
   context 'with disable_swap => true' do
@@ -418,6 +440,7 @@ describe 'kubernetes::packages', :type => :class do
         'create_repos' => true,
         'docker_log_max_file' => '1',
         'docker_log_max_size' => '100m',
+        'pin_packages'  => true,
         }
     end
     it { should contain_kmod__load('br_netfilter')}
@@ -431,6 +454,8 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"dm.use_deferred_deletion=true"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"default-runtime": "runc"\s*/)}
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
+    it { should_not contain_file('/etc/apt/preferences.d/docker')}
+    it { should contain_file('/etc/apt/preferences.d/kubernetes')}
     it { should_not contain_file('/etc/systemd/system/docker.service.d')}
   end
 end

--- a/templates/docker_apt_package_pins.erb
+++ b/templates/docker_apt_package_pins.erb
@@ -1,0 +1,16 @@
+###############################################################################
+###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
+
+<% @kube_packages.each do |package| -%>
+Package: <%= package %>
+Pin: version <%= @kubernetes_package_version  %>
+Pin-Priority: <%= @package_pin_priority %>
+
+<% end -%>
+
+###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
+###############################################################################
+
+
+
+

--- a/templates/kubernetes_apt_package_pins.erb
+++ b/templates/kubernetes_apt_package_pins.erb
@@ -1,0 +1,13 @@
+###############################################################################
+###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
+
+Package: <%= @docker_package_name %>
+Pin: version <%= @docker_version  %>
+Pin-Priority: <%= @package_pin_priority %>
+
+###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
+###############################################################################
+
+
+
+


### PR DESCRIPTION
- add option for package pinning on debian and ubuntu to prevent
  accidential upgrades
- make dashboard installation more reliable
- simple reformatting to satisfy formatting rules
- adapt an enhance tests for the changes above
- add /usr/bin to default_path to solve #415

Sorry, i was not successful in executing the litmus tests described in the "Development" section on my ubuntu 18.04 system. "litmus:install_module" dropped very cryptic messages which were not understandable for a litmus newbie....
So probably you can fix potential acceptance test problems to get these useful changes to upstream?
