### PR TITLE
Added Arm64 jobs for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,24 @@ jobs:
       env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
     -
+      arch: arm64
+      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      stage: static
+    -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.5
       stage: spec
     -
+      arch: arm64
+      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.9
+      stage: spec
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.7
+      stage: spec
+    -
+      arch: arm64
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7
       stage: spec


### PR DESCRIPTION
**PR Description :**

- Added Arm64 jobs for Travis-CI
- Modified RVM version for Arm64 platform, as version 2.4.5 is not available for arm64 platform

Tested the changes Locally and all the builds are passing.