### PR TITLE
Implement advertise address for etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,15 @@ A Hiera is `kubernetes::etcd_ip:"%{networking.ip}"`.
 
 Defaults to `undef`.
 
+#### `etcd_advertise_ip`
+
+Specifies the IP address etcd can be reached from.
+Useful when using a proxy or floating IP.
+
+A Hiera example is `kubernetes::etcd_advertise_ip:10.0.0.10`.
+
+Defaults to the same value as `etc_ip`.
+
 #### `etcd_initial_cluster`
 
 Informs etcd on how many nodes are in the cluster.

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -19,6 +19,7 @@ class kubernetes::config::kubeadm (
   Array $etcd_peers = $kubernetes::etcd_peers,
   String $etcd_hostname = $kubernetes::etcd_hostname,
   String $etcd_ip = $kubernetes::etcd_ip,
+  String $etcd_advertise_ip = $kubernetes::etcd_advertise_ip,
   String $cni_pod_cidr = $kubernetes::cni_pod_cidr,
   Integer $kube_api_bind_port = $kubernetes::kube_api_bind_port,
   String $kube_api_advertise_address = $kubernetes::kube_api_advertise_address,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,11 @@
 #   Or to pin explicitly to a specific interface kubernetes::etcd_ip: "%{::ipaddress_enp0s8}"
 #   Defaults to undef
 #
+# [*etcd_advertise_ip*]
+#   The ip address that you want etcd to advertise.
+#   Useful when using a proxy or floating IP.
+#   Defaults to the value of etcd_ip
+#
 # [*etcd_peers*]
 #   This will tell etcd how the list of peers to connect to into the cluster.
 #   An example with hiera would be kubernetes::etcd_peers:
@@ -466,6 +471,7 @@ class kubernetes (
   Optional[String] $etcd_version                     = '3.2.18',
   Optional[String] $etcd_hostname                    = $facts['hostname'],
   Optional[String] $etcd_ip                          = undef,
+  Optional[String] $etcd_advertise_ip                = $etcd_ip,
   Optional[Array] $etcd_peers                        = undef,
   Optional[String] $etcd_initial_cluster             = undef,
   Optional[String] $etcd_discovery_srv               = undef,

--- a/templates/etcd/etcd.erb
+++ b/templates/etcd/etcd.erb
@@ -6,7 +6,7 @@ ETCD_LISTEN_CLIENT_URLS="https://<%= @etcd_ip %>:2379"
 ETCD_DISCOVERY_SRV="<%= @etcd_discovery_srv %>"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://<%= @etcd_hostname %>:2380"
 <% else -%>
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://<%= @etcd_ip %>:2380"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://<%= @etcd_advertise_ip %>:2380"
 ETCD_INITIAL_CLUSTER="<%= @etcd_initial_cluster %>"
 <% end -%>
 ETCD_INITIAL_CLUSTER_STATE="new"
@@ -16,7 +16,7 @@ ETCD_AUTO_COMPACTION_MODE="<%= @etcd_compaction_method %>"
 <% end -%>
 ETCD_AUTO_COMPACTION_RETENTION="<%= @etcd_compaction_retention %>"
 ETCD_MAX_WALS="<%= @etcd_max_wals %>"
-ETCD_ADVERTISE_CLIENT_URLS="https://<%= @etcd_ip %>:2379"
+ETCD_ADVERTISE_CLIENT_URLS="https://<%= @etcd_advertise_ip %>:2379"
 ETCD_CERT_FILE="/etc/kubernetes/pki/etcd/server.crt"
 ETCD_KEY_FILE="/etc/kubernetes/pki/etcd/server.key"
 ETCD_CLIENT_CERT_AUTH=1

--- a/templates/etcd/etcd.service.erb
+++ b/templates/etcd/etcd.service.erb
@@ -14,12 +14,12 @@ TimeoutStartSec=0
 ExecStart=/usr/local/bin/etcd --name <%= @etcd_hostname %> \
     --data-dir /var/lib/etcd \
     --listen-client-urls https://<%= @etcd_ip %>:2379 \
-    --advertise-client-urls https://<%= @etcd_ip %>:2379 \
+    --advertise-client-urls https://<%= @etcd_advertise_ip %>:2379 \
     --listen-peer-urls https://<%= @etcd_ip %>:2380 \
 <% if @etcd_discovery_srv -%>
     --initial-advertise-peer-urls https://<%= @etcd_hostname %>:2380 \
 <% else -%>
-    --initial-advertise-peer-urls https://<%= @etcd_ip %>:2380 \
+    --initial-advertise-peer-urls https://<%= @etcd_advertise_ip %>:2380 \
 <% end -%>
     --cert-file=/etc/kubernetes/pki/etcd/server.crt \
     --key-file=/etc/kubernetes/pki/etcd/server.key \


### PR DESCRIPTION
In some setups the listening address and externally visible address can
be different. For instance in openstack setups with floating IPs, or
when using NAT. This change makes it possible to use different
addresses.