### PR TITLE
Add configuration options for conntrack settings in v1beta1 and v1beta2

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -56,6 +56,10 @@ class kubernetes::config::kubeadm (
   String $cgroup_driver = $kubernetes::cgroup_driver,
   String $proxy_mode = $kubernetes::proxy_mode,
   Stdlib::IP::Address $metrics_bind_address = $kubernetes::metrics_bind_address,
+  Integer $conntrack_max_per_core = $kubernetes::conntrack_max_per_core,
+  Integer $conntrack_min = $kubernetes::conntrack_min,
+  String $conntrack_tcp_wait_timeout = $kubernetes::conntrack_tcp_wait_timeout,
+  String $conntrack_tcp_stablished_timeout = $kubernetes::conntrack_tcp_stablished_timeout,
 ) {
   if !($proxy_mode in ['', 'userspace', 'iptables', 'ipvs', 'kernelspace']) {
     fail('Invalid kube-proxy mode! Must be one of "", userspace, iptables, ipvs, kernelspace.')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -448,6 +448,24 @@
 # Set the metricsBindAddress (to allow prometheus)
 # Default to 127.0.0.1
 #
+# [*conntrack_max_per_core*]
+# Maximum number of NAT connections to track per CPU core.
+# Set to 0 to leave the limit as-is and ignore conntrack_min.
+# Default to 32768
+#
+# [*conntrack_min*]
+# Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core.
+# Set conntrack_max_per_core to 0 to leave the limit as-is
+# Default to 131072
+#
+# [*conntrack_tcp_wait_timeout*]
+# NAT timeout for TCP connections in the CLOSE_WAIT state.
+# Default to 1h0m0s
+#
+# [*conntrack_tcp_stablished_timeout*]
+# Idle timeout for established TCP connections (0 to leave as-is).
+# Default to 24h0m0s
+#
 # Authors
 # -------
 #
@@ -580,6 +598,10 @@ class kubernetes (
   Optional[Array] $ignore_preflight_errors                       = undef,
   Stdlib::IP::Address $metrics_bind_address                      = '127.0.0.1',
   Optional[String] $join_discovery_file                          = undef,
+  Integer $conntrack_max_per_core                                = 32768,
+  Integer $conntrack_min                                         = 131072,
+  String $conntrack_tcp_wait_timeout                             = '1h0m0s',
+  String $conntrack_tcp_stablished_timeout                       = '24h0m0s',
 ) {
   if !$facts['os']['family'] in ['Debian', 'RedHat'] {
     notify { "The OS family ${facts['os']['family']} is not supported by this module": }

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -479,6 +479,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[2]['conntrack']['tcpEstablishedTimeout']).to eq('0h0m0s')
     end
   end
+
   context 'with conntrack settings version = 1.16' do
     let(:params) do
       {
@@ -506,5 +507,4 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[2]['conntrack']['tcpEstablishedTimeout']).to eq('0h0m0s')
     end
   end
-
 end

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -451,4 +451,60 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it { is_expected.to compile.and_raise_error(%r{metrics_bind_address}) }
   end
+
+  context 'with conntrack settings version = 1.14' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.14.2',
+        'conntrack_max_per_core' => 0,
+        'conntrack_min' => 0,
+        'conntrack_tcp_wait_timeout' => '0h0m0s',
+        'conntrack_tcp_stablished_timeout' => '0h0m0s',
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it 'has 0 in kube_proxy_conntrack_max_per_core:' do
+      expect(config_yaml[2]['conntrack']['maxPerCore']).to eq(0)
+    end
+    it 'has 0 in kube_proxy_conntrack_min:' do
+      expect(config_yaml[2]['conntrack']['min']).to eq(0)
+    end
+    it 'has 0h0m0s in kube_proxy_conntrack_tcp_wait_timeout:' do
+      expect(config_yaml[2]['conntrack']['tcpCloseWaitTimeout']).to eq('0h0m0s')
+    end
+    it 'has 0h0m0s in kube_proxy_conntrack_tcp_stablished_timeout:' do
+      expect(config_yaml[2]['conntrack']['tcpEstablishedTimeout']).to eq('0h0m0s')
+    end
+  end
+  context 'with conntrack settings version = 1.16' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.16.2',
+        'conntrack_max_per_core' => 0,
+        'conntrack_min' => 0,
+        'conntrack_tcp_wait_timeout' => '0h0m0s',
+        'conntrack_tcp_stablished_timeout' => '0h0m0s',
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it 'has 0 in kube_proxy_conntrack_max_per_core:' do
+      expect(config_yaml[2]['conntrack']['maxPerCore']).to eq(0)
+    end
+    it 'has 0 in kube_proxy_conntrack_min:' do
+      expect(config_yaml[2]['conntrack']['min']).to eq(0)
+    end
+    it 'has 0h0m0s in kube_proxy_conntrack_tcp_wait_timeout:' do
+      expect(config_yaml[2]['conntrack']['tcpCloseWaitTimeout']).to eq('0h0m0s')
+    end
+    it 'has 0h0m0s in kube_proxy_conntrack_tcp_stablished_timeout:' do
+      expect(config_yaml[2]['conntrack']['tcpEstablishedTimeout']).to eq('0h0m0s')
+    end
+  end
+
 end

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -109,10 +109,10 @@ clientConnection:
 clusterCIDR: <%= @cni_pod_cidr %>
 configSyncPeriod: 15m0s
 conntrack:
-  maxPerCore: 32768
-  min: 131072
-  tcpCloseWaitTimeout: 1h0m0s
-  tcpEstablishedTimeout: 24h0m0s
+  maxPerCore: <%= @conntrack_max_per_core %>
+  min: <%= @conntrack_min %>
+  tcpCloseWaitTimeout: <%= @conntrack_tcp_wait_timeout %>
+  tcpEstablishedTimeout: <%= @conntrack_tcp_stablished_timeout %>
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -111,10 +111,10 @@ clientConnection:
 clusterCIDR: <%= @cni_pod_cidr %>
 configSyncPeriod: 15m0s
 conntrack:
-  maxPerCore: 32768
-  min: 131072
-  tcpCloseWaitTimeout: 1h0m0s
-  tcpEstablishedTimeout: 24h0m0s
+  maxPerCore: <%= @conntrack_max_per_core %>
+  min: <%= @conntrack_min %>
+  tcpCloseWaitTimeout: <%= @conntrack_tcp_wait_timeout %>
+  tcpEstablishedTimeout: <%= @conntrack_tcp_stablished_timeout %>
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""


### PR DESCRIPTION
This PR adds support for configuring conntrack settings in kubeadm config.yaml file.