### PR TITLE
Remove invalid kube-proxy config resourceContainer

### DIFF
--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -132,5 +132,4 @@ mode: "<%= @proxy_mode %>"
 nodePortAddresses: null
 oomScoreAdj: -999
 portRange: ""
-resourceContainer: /kube-proxy
 udpIdleTimeout: 250ms

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -134,5 +134,4 @@ mode: "<%= @proxy_mode %>"
 nodePortAddresses: null
 oomScoreAdj: -999
 portRange: ""
-resourceContainer: /
 udpIdleTimeout: 250ms


### PR DESCRIPTION
Commit to remove applies to  Kubernetes 1.16.0+
https://github.com/kubernetes/kubernetes/commit/eee3e976d871bcbf97821a0fa9c129a4c568ac5e

Error with this config deployed on 1.17.2:

```
W1105 15:55:06.751793   19570 strict.go:54] error unmarshaling configuration schema.GroupVersionKind{Group:"kubeproxy.config.k8s.io", Version:"v1alpha1", Kind:"KubeProxyConfiguration"}: error unmarshaling JSON: while decoding JSON: json: unknown field "resourceContainer"
```