### PR TITLE
Add scheduler_extra_arguments parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ controllermanager_extra_volumes => {
 
 Defaults to `{}`.
 
+#### `scheduler_extra_arguments`
+
+A string array of extra arguments passed to the scheduler.
+
+Defaults to `[]`.
 
 #### `create_repos`
 

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -43,6 +43,7 @@ class kubernetes::config::kubeadm (
   Optional[Array] $apiserver_cert_extra_sans = $kubernetes::apiserver_cert_extra_sans,
   Optional[Array] $apiserver_extra_arguments = $kubernetes::apiserver_extra_arguments,
   Optional[Array] $controllermanager_extra_arguments = $kubernetes::controllermanager_extra_arguments,
+  Optional[Array] $scheduler_extra_arguments = $kubernetes::scheduler_extra_arguments,
   Optional[Array] $kubelet_extra_arguments = $kubernetes::kubelet_extra_arguments,
   String $service_cidr = $kubernetes::service_cidr,
   String $node_name = $kubernetes::node_name,
@@ -124,6 +125,7 @@ class kubernetes::config::kubeadm (
     }
     $apiserver_merged_extra_arguments = concat($apiserver_extra_arguments, $cloud_args)
     $controllermanager_merged_extra_arguments = concat($controllermanager_extra_arguments, $cloud_args)
+    $scheduler_merged_extra_arguments = concat($scheduler_extra_arguments, $cloud_args)
 
     # could check against Kubernetes 1.10 here, but that uses alpha1 config which doesn't have these options
     if $cloud_config {
@@ -147,6 +149,7 @@ class kubernetes::config::kubeadm (
   } else {
     $apiserver_merged_extra_arguments = $apiserver_extra_arguments
     $controllermanager_merged_extra_arguments = $controllermanager_extra_arguments
+    $scheduler_merged_extra_arguments = $scheduler_extra_arguments
 
     $apiserver_merged_extra_volumes = $apiserver_extra_volumes
     $controllermanager_merged_extra_volumes = $controllermanager_extra_volumes

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,6 +233,10 @@
 #   A hash of extra volume mounts mounted on the controller manager.
 #   Defaults to []
 #
+# [*scheduler_extra_arguments*]
+#   A string array of extra arguments to be passed to scheduler.
+#   Defaults to []
+#
 # [*delegated_pki*]
 #   Set to true if all required X509 certificates will be provided by external means. Setting this to true will ignore all *_crt and *_key including sa.key and sa.pub files.
 #   Defaults to false
@@ -517,6 +521,7 @@ class kubernetes (
   Optional[Array] $apiserver_cert_extra_sans                     = [],
   Optional[Array] $apiserver_extra_arguments                     = [],
   Optional[Array] $controllermanager_extra_arguments             = [],
+  Optional[Array] $scheduler_extra_arguments                     = [],
   String $service_cidr                                           = '10.96.0.0/12',
   Optional[String] $node_label                                   = undef,
   Optional[String] $controller_address                           = undef,

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -327,6 +327,25 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     let(:params) do
       {
         'kubernetes_version' => '1.14.1',
+        'scheduler_extra_arguments' => ['foo', 'bar'],
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
+    it 'has foo in scheduler arguments' do
+      expect(config_yaml[1]['scheduler']['extraArgs']).to include('foo')
+    end
+    it 'has bar in scheduler arguments' do
+      expect(config_yaml[1]['scheduler']['extraArgs']).to include('bar')
+    end
+  end
+
+  context 'with version = 1.14' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.14.1',
         'apiserver_extra_volumes' => {
           'foo' => {
             'hostPath'  => '/mnt',

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -76,6 +76,13 @@ controllerManager:
     pathType: <%= config['pathType'] %>
   <%- end -%>
 <%- end -%>
+scheduler:
+<%- if @scheduler_merged_extra_arguments -%>
+  extraArgs:
+  <%- @scheduler_merged_extra_arguments.each do |arg| -%>
+    <%= arg %>
+  <%- end -%>
+<%- end -%>
 dns:
   type: CoreDNS
 etcd:

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -78,6 +78,13 @@ controllerManager:
     pathType: <%= config['pathType'] %>
   <%- end -%>
 <%- end -%>
+scheduler:
+<%- if @scheduler_merged_extra_arguments -%>
+  extraArgs:
+  <%- @scheduler_merged_extra_arguments.each do |arg| -%>
+    <%= arg %>
+  <%- end -%>
+<%- end -%>
 dns:
   type: CoreDNS
 etcd:


### PR DESCRIPTION
Upstream docs: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#scheduler-flags

Appears valid as far back as docs go that I could find: https://v1-15.docs.kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#scheduler-flags

One example of how I am going to use this:

```yaml
kubernetes::scheduler_extra_arguments:
  - 'bind-address: 0.0.0.0'
```