### PR TITLE
IAC-1246 - Remove RedHat support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,13 +39,6 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7"

--- a/provision.yaml
+++ b/provision.yaml
@@ -20,13 +20,9 @@ all_supported:
 release_checks:
   provisioner: abs
   images:
-  - redhat-7-x86_64
-  - redhat-8-x86_64
   - centos-7-x86_64
   - ubuntu-1604-x86_64
 release_checks_7:
   provisioner: abs
   images:
-  - redhat-7-x86_64
-  - redhat-8-x86_64
   - centos-7-x86_64


### PR DESCRIPTION
Remove RedHat support because Docker and RedHat are no longer officially a supported combination.
See: docker/docker-install#190