### PR TITLE
Support installing containerd using a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,18 @@ Specifies the version of the containerd runtime the module installs.
 
 Defaults to `1.1.0`.
 
+### `containerd_install_method`
+
+The method used to install containerd. Either `archive` or `package`.
+
+Defaults to `archive`.
+
+### `containerd_package_name`
+
+The package name for containerd when `containerd_install_method` is `package`.
+
+Defaults to `containerd.io`
+
 #### `containerd_archive`
 
 The name of the containerd archive.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,14 @@
 #   This is the version of the containerd runtime the module will install.
 #   Defaults to 1.1.0
 #
+# [*containerd_install_method*]
+#   Whether to install containerd via archive or package.
+#   Defaults to archive
+#
+# [*containerd_package_name*]
+#   containerd package name
+#   Defaults to containerd.io
+#
 # [*containerd_archive*]
 #  The name of the containerd archive
 #  Defaults to containerd-${containerd_version}.linux-amd64.tar.gz
@@ -486,6 +494,8 @@ class kubernetes (
   },
   String $container_runtime                                      = 'docker',
   Optional[String] $containerd_version                           = '1.1.0',
+  Enum['archive','package'] $containerd_install_method           = 'archive',
+  String $containerd_package_name                                = 'containerd.io',
   Optional[String] $docker_package_name                          = 'docker-engine',
   Optional[String] $docker_version                               = $facts['os']['family'] ? {
     'Debian' => '17.03.0~ce-0~ubuntu-xenial',

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,23 +1,24 @@
 ## kubernetes repos
 
 class kubernetes::repos (
-  String $container_runtime                 = $kubernetes::container_runtime,
-  Optional[String] $kubernetes_apt_location = $kubernetes::kubernetes_apt_location,
-  Optional[String] $kubernetes_apt_release  = $kubernetes::kubernetes_apt_release,
-  Optional[String] $kubernetes_apt_repos    = $kubernetes::kubernetes_apt_repos,
-  Optional[String] $kubernetes_key_id       = $kubernetes::kubernetes_key_id,
-  Optional[String] $kubernetes_key_source   = $kubernetes::kubernetes_key_source,
-  Optional[String] $kubernetes_yum_baseurl  = $kubernetes::kubernetes_yum_baseurl,
-  Optional[String] $kubernetes_yum_gpgkey   = $kubernetes::kubernetes_yum_gpgkey,
-  Optional[String] $docker_apt_location     = $kubernetes::docker_apt_location,
-  Optional[String] $docker_apt_release      = $kubernetes::docker_apt_release,
-  Optional[String] $docker_apt_repos        = $kubernetes::docker_apt_repos,
-  Optional[String] $docker_yum_baseurl      = $kubernetes::docker_yum_baseurl,
-  Optional[String] $docker_yum_gpgkey       = $kubernetes::docker_yum_gpgkey,
-  Optional[String] $docker_key_id           = $kubernetes::docker_key_id,
-  Optional[String] $docker_key_source       = $kubernetes::docker_key_source,
-  Boolean $manage_docker                    = $kubernetes::manage_docker,
-  Boolean $create_repos                     = $kubernetes::create_repos,
+  String $container_runtime                   = $kubernetes::container_runtime,
+  Optional[String] $kubernetes_apt_location   = $kubernetes::kubernetes_apt_location,
+  Optional[String] $kubernetes_apt_release    = $kubernetes::kubernetes_apt_release,
+  Optional[String] $kubernetes_apt_repos      = $kubernetes::kubernetes_apt_repos,
+  Optional[String] $kubernetes_key_id         = $kubernetes::kubernetes_key_id,
+  Optional[String] $kubernetes_key_source     = $kubernetes::kubernetes_key_source,
+  Optional[String] $kubernetes_yum_baseurl    = $kubernetes::kubernetes_yum_baseurl,
+  Optional[String] $kubernetes_yum_gpgkey     = $kubernetes::kubernetes_yum_gpgkey,
+  Optional[String] $docker_apt_location       = $kubernetes::docker_apt_location,
+  Optional[String] $docker_apt_release        = $kubernetes::docker_apt_release,
+  Optional[String] $docker_apt_repos          = $kubernetes::docker_apt_repos,
+  Optional[String] $docker_yum_baseurl        = $kubernetes::docker_yum_baseurl,
+  Optional[String] $docker_yum_gpgkey         = $kubernetes::docker_yum_gpgkey,
+  Optional[String] $docker_key_id             = $kubernetes::docker_key_id,
+  Optional[String] $docker_key_source         = $kubernetes::docker_key_source,
+  Optional[String] $containerd_install_method = $kubernetes::containerd_install_method,
+  Boolean $manage_docker                      = $kubernetes::manage_docker,
+  Boolean $create_repos                       = $kubernetes::create_repos,
 
 ) {
   if $create_repos {
@@ -34,7 +35,8 @@ class kubernetes::repos (
           },
         }
 
-        if $container_runtime == 'docker' and $manage_docker == true {
+        if ($container_runtime == 'docker' and $manage_docker == true) or
+            ($container_runtime == 'cri_containerd' and $containerd_install_method == 'package') {
           apt::source { 'docker':
             location => pick($docker_apt_location,'https://apt.dockerproject.org/repo'),
             repos    => pick($docker_apt_repos,'main'),
@@ -47,7 +49,8 @@ class kubernetes::repos (
         }
       }
       'RedHat': {
-        if $container_runtime == 'docker' and $manage_docker == true {
+        if ($container_runtime == 'docker' and $manage_docker == true) or
+            ($container_runtime == 'cri_containerd' and $containerd_install_method == 'package') {
           yumrepo { 'docker':
             descr    => 'docker',
             baseurl  => pick($docker_yum_baseurl,'https://download.docker.com/linux/centos/7/x86_64/stable'),

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -35,6 +35,9 @@ describe 'kubernetes::packages', :type => :class do
         'container_runtime' => 'docker',
         'kubernetes_package_version' => '1.10.2',
         'docker_version' => '17.03.1.ce-1.el7.centos',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'archive',
+        'containerd_package_name' => 'containerd.io',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
@@ -64,6 +67,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
@@ -119,6 +123,9 @@ describe 'kubernetes::packages', :type => :class do
         'container_runtime' => 'docker',
         'kubernetes_package_version' => '1.10.2',
         'docker_version' => '17.03.1.ce-1.el7.centos',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'archive',
+        'containerd_package_name' => 'containerd.io',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
@@ -148,6 +155,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
@@ -174,6 +182,78 @@ describe 'kubernetes::packages', :type => :class do
         .send(:parameters)[:content]
       expect { JSON.parse(json_data) }.to_not raise_error
     end
+  end
+
+  context 'with osfamily => RedHat and container_runtime => cri_containerd and containerd_install_method => package and manage_etcd => true' do
+    let(:facts) do
+      {
+        :osfamily         => 'RedHat', #needed to run dependent tests from fixtures camptocamp-kmod
+        :kernel           => 'Linux',
+        :os               => {
+          :family => "RedHat",
+          :name    => 'RedHat',
+          :release => {
+            :full => '7.4',
+          },
+        },
+      }
+    end
+    let(:pre_condition) {
+       '
+       exec { \'kubernetes-systemd-reload\': }
+       service { \'etcd\': }
+       service { \'containerd\': }
+       '
+    }
+    let(:params) do
+        {
+        'container_runtime' => 'cri_containerd',
+        'kubernetes_package_version' => '1.10.2',
+        'docker_version' => '17.03.1.ce-1.el7.centos',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'package',
+        'containerd_package_name' => 'containerd.io',
+        'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
+        'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
+        'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
+        'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
+        'runc_source' => 'https://github.com/runcsource',
+        'controller' => true,
+        'docker_package_name' => 'docker-engine',
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => ['dm.use_deferred_removal=true','dm.use_deferred_deletion=true'],
+        'docker_extra_daemon_config' => '',
+        'docker_cgroup_driver' => 'systemd',
+        'disable_swap' => true,
+        'manage_docker' => true,
+        'manage_etcd' => true,
+        'manage_kernel_modules' => true,
+        'manage_sysctl_settings' => true,
+        'etcd_install_method' => 'wget',
+        'etcd_package_name' => 'etcd-server',
+        'etcd_version' => '3.1.12',
+        'create_repos' => true,
+        'docker_log_max_file' => '1',
+        'docker_log_max_size' => '100m',
+        'pin_packages'  => false,
+        'containerd_archive_checksum' => nil,
+        'etcd_archive_checksum' => nil,
+        'runc_source_checksum' => nil,
+        }
+    end
+    it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
+    it { should contain_kmod__load('br_netfilter')}
+    it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
+    it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
+    it { should contain_package('containerd.io').with_ensure('1.1.0')}
+    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should contain_package('kubelet').with_ensure('1.10.2')}
+    it { should contain_package('kubectl').with_ensure('1.10.2')}
+    it { should contain_package('kubeadm').with_ensure('1.10.2')}
+    it { should contain_file('/etc/containerd')}
+    it { should contain_file('/etc/containerd/config.toml')}
+    it { should_not contain_file('/etc/apt/preferences.d/containerd')}
   end
 
   context 'with osfamily => Debian and container_runtime => cri_containerd and manage_etcd => false' do
@@ -206,6 +286,9 @@ describe 'kubernetes::packages', :type => :class do
         'container_runtime' => 'cri_containerd',
         'kubernetes_package_version' => '1.10.2-00',
         'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'archive',
+        'containerd_package_name' => 'containerd.io',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
@@ -235,6 +318,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
@@ -289,6 +373,9 @@ describe 'kubernetes::packages', :type => :class do
         'container_runtime' => 'docker',
         'kubernetes_package_version' => '1.10.2',
         'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'archive',
+        'containerd_package_name' => 'containerd.io',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
@@ -318,6 +405,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
@@ -372,6 +460,9 @@ describe 'kubernetes::packages', :type => :class do
         'container_runtime' => 'docker',
         'kubernetes_package_version' => '1.10.2',
         'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'archive',
+        'containerd_package_name' => 'containerd.io',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
@@ -401,6 +492,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
@@ -418,6 +510,83 @@ describe 'kubernetes::packages', :type => :class do
     it { should_not contain_file('/etc/docker/daemon.json').with_content(/\s*"native.cgroupdriver=systemd"\s*/)}
     it { should_not contain_file('/etc/apt/preferences.d/docker')}
     it { should contain_file('/etc/apt/preferences.d/kubernetes')}
+  end
+
+  context 'with osfamily => Debian and container_runtime => cri_containerd and containerd_install_method => package and manage_etcd => true' do
+    let(:facts) do
+      {
+        :osfamily         => 'Debian', #needed to run dependent tests from fixtures camptocamp-kmod
+        :kernel           => 'Linux',
+        :os               => {
+          :family => "Debian",
+          :name    => 'Ubuntu',
+          :release => {
+            :full => '16.04',
+          },
+          :distro => {
+            :codename => "xenial",
+          },
+        },
+      }
+    end
+    let(:pre_condition) {
+       '
+       include apt
+       exec { \'kubernetes-systemd-reload\': }
+       service { \'etcd\': }
+       service { \'containerd\': }
+       '
+    }
+
+    let(:params) do
+        {
+        'container_runtime' => 'cri_containerd',
+        'kubernetes_package_version' => '1.10.2',
+        'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'package',
+        'containerd_package_name' => 'containerd.io',
+        'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
+        'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
+        'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
+        'etcd_source' => 'https://github.com/etcd-v3.1.12.tar.gz',
+        'runc_source' => 'https://github.com/runcsource',
+        'controller' => true,
+        'docker_package_name' => 'docker-engine',
+        'docker_storage_driver' => 'overlay2',
+        'docker_storage_opts' => [],
+        'docker_extra_daemon_config' => '"default-runtime": "runc"',
+        'docker_cgroup_driver' => 'systemd',
+        'disable_swap' => true,
+        'manage_docker' => true,
+        'manage_etcd' => true,
+        'manage_kernel_modules' => true,
+        'manage_sysctl_settings' => true,
+        'etcd_install_method' => 'wget',
+        'etcd_package_name' => 'etcd-server',
+        'etcd_version' => '3.1.12',
+        'create_repos' => true,
+        'docker_log_max_file' => '1',
+        'docker_log_max_size' => '100m',
+        'pin_packages'  => true,
+        'containerd_archive_checksum' => nil,
+        'etcd_archive_checksum' => nil,
+        'runc_source_checksum' => nil,
+        }
+    end
+    it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
+    it { should contain_kmod__load('br_netfilter')}
+    it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
+    it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}
+    it { should contain_archive('etcd-v3.1.12-linux-amd64.tar.gz')}
+    it { should contain_package('kubelet').with_ensure('1.10.2')}
+    it { should contain_package('kubectl').with_ensure('1.10.2')}
+    it { should contain_package('kubeadm').with_ensure('1.10.2')}
+    it { should contain_package('containerd.io').with_ensure('1.1.0')}
+    it { should contain_file('/etc/containerd')}
+    it { should contain_file('/etc/containerd/config.toml')}
+    it { should contain_file('/etc/apt/preferences.d/containerd')}
   end
 
   context 'with disable_swap => true' do
@@ -450,6 +619,9 @@ describe 'kubernetes::packages', :type => :class do
         'container_runtime' => 'cri_containerd',
         'kubernetes_package_version' => '1.10.2-00',
         'docker_version' => '17.03.0~ce-0~ubuntu-xenial',
+        'containerd_version' => '1.1.0',
+        'containerd_install_method' => 'archive',
+        'containerd_package_name' => 'containerd.io',
         'containerd_archive' =>'containerd-1.1.0.linux-amd64.tar.gz',
         'containerd_source' => 'https://github.com/containerd-1.1.0.linux-amd64.tar.gz',
         'etcd_archive' => 'etcd-v3.1.12-linux-amd64.tar.gz',
@@ -479,6 +651,7 @@ describe 'kubernetes::packages', :type => :class do
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
+    it { should contain_kmod__load('overlay')}
     it { should contain_kmod__load('br_netfilter')}
     it { should contain_sysctl('net.bridge.bridge-nf-call-iptables').with_ensure('present').with_value('1')}
     it { should contain_sysctl('net.ipv4.ip_forward').with_ensure('present').with_value('1')}

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -36,8 +36,66 @@ describe 'kubernetes::repos', :type => :class do
          'docker_yum_gpgkey' => 'https://download.docker.com/linux/centos/gpg',
          'docker_key_id' => '58118E89F3A912897C070ADBF76221572C52609D',
          'docker_key_source' => 'https://apt.dockerproject.org/gpg',
-         'create_repos' => true,         
-         'manage_docker' => true, 
+         'containerd_install_method' => 'archive',
+         'create_repos' => true,
+         'manage_docker' => true,
+       }
+    end
+
+    it { should contain_apt__source('kubernetes').with(
+      :ensure   => 'present',
+      :location => 'http://apt.kubernetes.io',
+      :repos    => 'main',
+      :release  => 'kubernetes-xenial',
+      :key      => { 'id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB', 'source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' }
+    ) }
+
+    it { should contain_apt__source('docker').with(
+      :ensure   => 'present',
+      :location => 'https://apt.dockerproject.org/repo',
+      :repos    => 'main',
+      :release  => 'ubuntu-xenial',
+      :key      => { 'id' => '58118E89F3A912897C070ADBF76221572C52609D', 'source' => 'https://apt.dockerproject.org/gpg' }
+    ) }
+  end
+
+  context 'with osfamily => Ubuntu and container_runtime => cri_containerd and containerd_install_method => package' do
+    let(:facts) do
+      {
+        :osfamily         => 'Debian', #needed to run dependent tests from fixtures puppetlabs-apt
+        :kernel           => 'Linux',
+        :os               => {
+          :family => 'Debian',
+          :name   => 'Ubuntu',
+          :release => {
+            :full => '16.04',
+          },
+          :distro => {
+            :codename => 'xenial',
+          },
+        },
+      }
+    end
+    let(:params) do
+       {
+         'container_runtime' => 'cri_containerd',
+         'kubernetes_apt_location' => 'http://apt.kubernetes.io',
+         'kubernetes_apt_release' => 'kubernetes-xenial',
+         'kubernetes_apt_repos' => 'main',
+         'kubernetes_key_id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB',
+         'kubernetes_key_source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
+         'kubernetes_yum_baseurl' => 'https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64',
+         'kubernetes_yum_gpgkey' => 'https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg',
+         'docker_apt_location' => 'https://apt.dockerproject.org/repo',
+         'docker_apt_release' => 'ubuntu-xenial',
+         'docker_apt_repos' => 'main',
+         'docker_yum_baseurl' => 'https://download.docker.com/linux/centos/7/x86_64/stable',
+         'docker_yum_gpgkey' => 'https://download.docker.com/linux/centos/gpg',
+         'docker_key_id' => '58118E89F3A912897C070ADBF76221572C52609D',
+         'docker_key_source' => 'https://apt.dockerproject.org/gpg',
+         'containerd_install_method' => 'package',
+         'create_repos' => true,
+         'manage_docker' => true,
        }
     end    
 
@@ -96,12 +154,61 @@ describe 'kubernetes::repos', :type => :class do
         'docker_yum_gpgkey' => 'https://download.docker.com/linux/centos/gpg',
         'docker_key_id' => '58118E89F3A912897C070ADBF76221572C52609D',
         'docker_key_source' => 'https://apt.dockerproject.org/gpg',
+        'containerd_install_method' => 'archive',
         'create_repos' => true,
         'manage_docker' => false,
        }
    end 
 
     it { should_not contain_yumrepo('docker') }
+    it { should contain_yumrepo('kubernetes') }
+  end
+
+  context 'with osfamily => RedHat and container_runtime => cri_containerd and containerd_install_method => package' do
+    let(:facts) do
+      {
+        :operatingsystem => 'RedHat',
+        :osfamily => 'RedHat',
+        :operatingsystemrelease => '7.0',
+      }
+    end
+    let(:facts) do
+      {
+        :kernel           => 'Linux',
+        :os               => {
+          :family  => 'RedHat',
+          :name    => 'RedHat',
+          :release => {
+            :full => '7.0',
+          },
+        },
+      }
+    end
+
+    let(:params) do
+      {
+        'container_runtime' => 'cri_containerd',
+        'kubernetes_apt_location' => 'http://apt.kubernetes.io',
+        'kubernetes_apt_release' => 'kubernetes-xenial',
+        'kubernetes_apt_repos' => 'main',
+        'kubernetes_key_id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB',
+        'kubernetes_key_source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
+        'kubernetes_yum_baseurl' => 'https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64',
+        'kubernetes_yum_gpgkey' => 'https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg',
+        'docker_apt_location' => 'https://apt.dockerproject.org/repo',
+        'docker_apt_release' => 'ubuntu-xenial',
+        'docker_apt_repos' => 'main',
+        'docker_yum_baseurl' => 'https://download.docker.com/linux/centos/7/x86_64/stable',
+        'docker_yum_gpgkey' => 'https://download.docker.com/linux/centos/gpg',
+        'docker_key_id' => '58118E89F3A912897C070ADBF76221572C52609D',
+        'docker_key_source' => 'https://apt.dockerproject.org/gpg',
+        'containerd_install_method' => 'package',
+        'create_repos' => true,
+        'manage_docker' => false,
+       }
+   end
+
+    it { should contain_yumrepo('docker') }
     it { should contain_yumrepo('kubernetes') }
   end
 end

--- a/templates/containerd/config.toml.erb
+++ b/templates/containerd/config.toml.erb
@@ -1,0 +1,119 @@
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+plugin_dir = ""
+disabled_plugins = []
+required_plugins = []
+oom_score = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  tcp_address = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[ttrpc]
+  address = ""
+  uid = 0
+  gid = 0
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[plugins]
+  [plugins."io.containerd.gc.v1.scheduler"]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_tcp_service = true
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    stream_idle_timeout = "4h0m0s"
+    enable_selinux = false
+    sandbox_image = "k8s.gcr.io/pause:3.1"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    disable_cgroup = false
+    disable_apparmor = false
+    restrict_oom_score_adj = false
+    max_concurrent_downloads = 3
+    disable_proc_mount = false
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      snapshotter = "overlayfs"
+      default_runtime_name = "runc"
+      no_pivot = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        runtime_type = ""
+        runtime_engine = ""
+        runtime_root = ""
+        privileged_without_host_devices = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        runtime_type = ""
+        runtime_engine = ""
+        runtime_root = ""
+        privileged_without_host_devices = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v1"
+          runtime_engine = ""
+          runtime_root = ""
+          privileged_without_host_devices = false
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      max_conf_num = 1
+      conf_template = ""
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+  [plugins."io.containerd.runtime.v1.linux"]
+    shim = "containerd-shim"
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    root_path = ""
+    pool_name = ""
+    base_image_size = ""

--- a/templates/containerd_apt_package_pins.erb
+++ b/templates/containerd_apt_package_pins.erb
@@ -1,12 +1,9 @@
 ###############################################################################
 ###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
 
-<% @kube_packages.each do |package| -%>
-Package: <%= package %>
-Pin: version <%= @kubernetes_package_version  %>
+Package: <%= @containerd_package_name %>
+Pin: version <%= @containerd_version  %>
 Pin-Priority: <%= @package_pin_priority %>
-
-<% end -%>
 
 ###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
 ###############################################################################

--- a/templates/docker_apt_package_pins.erb
+++ b/templates/docker_apt_package_pins.erb
@@ -1,12 +1,9 @@
 ###############################################################################
 ###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
 
-<% @kube_packages.each do |package| -%>
-Package: <%= package %>
-Pin: version <%= @kubernetes_package_version  %>
+Package: <%= @docker_package_name %>
+Pin: version <%= @docker_version  %>
 Pin-Priority: <%= @package_pin_priority %>
-
-<% end -%>
 
 ###      THIS FILE IS MANAGED BY PUPPET - ALL CHANGES WILL BE REVERTED      ###
 ###############################################################################


### PR DESCRIPTION
To maintain backwards compatibility I made the package install of containerd opt-in via a parameter. If it would be preferred I can make the package install method the only way to install containerd.

Docs: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd

One motivation behind this is being able to use Puppet to pin package versions, where the archive approach doesn't lend itself to upgrades via Puppet without deleting something like `/usr/bin/runc` or `/usr/bin/containerd` and re-running Puppet.  Also Kubernetes 1.20 future release will deprecate Docker as container runtime so felt it would be good to improve on the containerd install method.

Also noticed a bug where the docker apt pinning was pinning kubernetes packages and the kubernetes apt pinning was referencing docker packages.