### PR TITLE
Allow tmp_directory to be changed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -482,6 +482,10 @@
 # Idle timeout for established TCP connections (0 to leave as-is).
 # Default to 24h0m0s
 #
+# [*tmp_directory*]
+# Directory to use when downloading archives for install.
+# Default to /var/tmp/puppetlabs-kubernetes
+#
 # Authors
 # -------
 #
@@ -622,6 +626,7 @@ class kubernetes (
   Integer $conntrack_min                                         = 131072,
   String $conntrack_tcp_wait_timeout                             = '1h0m0s',
   String $conntrack_tcp_stablished_timeout                       = '24h0m0s',
+  String $tmp_directory                                          = '/var/tmp/puppetlabs-kubernetes',
 ) {
   if !$facts['os']['family'] in ['Debian', 'RedHat'] {
     notify { "The OS family ${facts['os']['family']} is not supported by this module": }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -35,9 +35,8 @@ class kubernetes::packages (
   Boolean $pin_packages                                 = $kubernetes::pin_packages,
   Integer $package_pin_priority                         = 32767,
   String $archive_checksum_type                         = 'sha256',
+  String $tmp_directory                                 = $kubernetes::tmp_directory,
 ) {
-  $tmp_directory = '/var/tmp/puppetlabs-kubernetes'
-
   # Download directory for archives
   file { $tmp_directory:
     ensure => 'directory',

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -64,6 +64,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -152,6 +153,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -239,6 +241,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -315,6 +318,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -402,6 +406,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -489,6 +494,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -572,6 +578,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => nil,
         'etcd_archive_checksum' => nil,
         'runc_source_checksum' => nil,
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}
@@ -648,6 +655,7 @@ describe 'kubernetes::packages', :type => :class do
         'containerd_archive_checksum' => 'bcab421f6bf4111accfceb004e0a0ac2bcfb92ac93081d9429e313248dd78c41',
         'etcd_archive_checksum' => 'bcab421f6bf4111accfceb004e0a0ac2bcfb92ac93081d9429e313248dd78c41',
         'runc_source_checksum' => 'bcab421f6bf4111accfceb004e0a0ac2bcfb92ac93081d9429e313248dd78c41',
+        'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
         }
     end
     it { should contain_file_line('remove swap in /etc/fstab')}


### PR DESCRIPTION
Using `/var/tmp` on systems, at least in my case, results in the directory getting purged by systemd tmp space cleanup and so after a few weeks Puppet has to add the directory back which is not ideal and state changes that are unnecessary.