### PR TITLE
Fix calico CNI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The above parameters are:
 * `VERSION`: The version of Kubernetes to deploy.
 * `CONTAINER_RUNTIME`: The container runtime Kubernetes uses. Set this value to `docker` (officially supported) or `cri_containerd`. Advanced Kubernetes users can use `cri_containerd`, however this requires an increased understanding of Kubernetes, specifically when running applications in a HA cluster. To run a HA cluster and access your applications, an external load balancer is required in front of your cluster. Setting this up is beyond the scope of this module. For more information, see the Kubernetes [documentation](https://kubernetes-v1-4.github.io/docs/user-guide/load-balancer/).
 * `CNI_PROVIDER`: The CNI network to install. Set this value to `weave`, `flannel`, `calico` or `cilium`.
-* `CNI_PROVIDER_VERSION` The CNI version to use `calico` and `cilium` use this variable to reference the correct deployment file. Current version for `calico` is `3.6` and `cilium` is `1.4.3`
+* `CNI_PROVIDER_VERSION` The CNI version to use. `cilium` uses this variable to reference the correct deployment file. Current version `cilium` is `1.4.3`
 * `ETCD_INITIAL_CLUSTER`: The server hostnames and IPs in the form of `hostname:ip`. When in production, include three, five, or seven nodes for etcd.
 * `ETCD_IP`: The IP each etcd member listens on. We recommend passing the fact for the interface to be used by the cluster.
 * `KUBE_API_ADVERTISE_ADDRESS`: The IP each etcd/apiserver instance uses on each controller. We recommend passing the fact for the interface to be used by the cluster.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,10 +67,19 @@
 #   The overlay (internal) network range to use.
 #   Defaults to undef. kube_tool sets this per cni provider.
 #
+# [*cni_network_preinstall*]
+#
+#  The URL to install the Tigera operator.
+#  Used only by calico.
+#
 # [*cni_network_provider*]
 #
 #  The URL to get the cni providers yaml file.
 #  Defaults to `undef`. `kube_tool` sets this value.
+#
+# [*cni_provider*]
+#
+#  The NAME of the CNI provider, as provided to kubetool.
 #
 # [*cni_rbac_binding*]
 #  The URL get the cni providers rbac rules. This is for use with Calico only.
@@ -533,7 +542,9 @@ class kubernetes (
   Optional[String] $etcdserver_key                               = undef,
   Optional[String] $etcdpeer_crt                                 = undef,
   Optional[String] $etcdpeer_key                                 = undef,
+  Optional[String] $cni_network_preinstall                       = undef,
   Optional[String] $cni_network_provider                         = undef,
+  Optional[String] $cni_provider                                 = undef,
   Optional[String] $cni_rbac_binding                             = undef,
   Boolean $install_dashboard                                     = false,
   String $dashboard_version                                      = 'v1.10.1',

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -1,7 +1,10 @@
 # Class kubernetes kube_addons
 class kubernetes::kube_addons (
 
+  Optional[String] $cni_network_preinstall  = $kubernetes::cni_network_preinstall,
   Optional[String] $cni_network_provider    = $kubernetes::cni_network_provider,
+  Optional[String] $cni_pod_cidr            = $kubernetes::cni_pod_cidr,
+  Optional[String] $cni_provider            = $kubernetes::cni_provider,
   Optional[String] $cni_rbac_binding        = $kubernetes::cni_rbac_binding,
   Boolean $install_dashboard                = $kubernetes::install_dashboard,
   String $dashboard_version                 = $kubernetes::dashboard_version,
@@ -32,12 +35,46 @@ class kubernetes::kube_addons (
   }
 
   if $cni_network_provider {
-    $shellsafe_provider = shell_escape($cni_network_provider)
-    exec { 'Install cni network provider':
-      command     => "kubectl apply -f ${shellsafe_provider}",
-      onlyif      => 'kubectl get nodes',
-      unless      => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'",
-      environment => $env,
+    if $cni_provider == 'calico' {
+      if $cni_network_preinstall {
+        $shellsafe_preinstall = shell_escape($cni_network_preinstall)
+        exec { 'Install cni network (preinstall)':
+          command     => "kubectl apply -f ${shellsafe_preinstall}",
+          onlyif      => 'kubectl get nodes',
+          unless      => "kubectl -n tigera-operator get deployments | egrep '^tigera-operator'",
+          environment => $env,
+          before      => Exec['Install cni network provider'],
+        }
+      }
+      $calico_installation_path='/etc/kubernetes/calico-installation.yaml'
+      file { $calico_installation_path:
+        ensure  => 'present',
+        group   => 'root',
+        mode    => '0400',
+        owner   => 'root',
+        replace => false,
+        source  => $cni_network_provider,
+      } -> file_line { 'Configure calico ipPools.cidr':
+        ensure   => present,
+        path     => $calico_installation_path,
+        match    => '      cidr:',
+        line     => "      cidr: ${cni_pod_cidr}",
+        multiple => false,
+        replace  => true,
+      } -> exec { 'Install cni network provider':
+        command     => "kubectl apply -f ${calico_installation_path}",
+        onlyif      => 'kubectl get nodes',
+        unless      => "kubectl -n calico-system get daemonset | egrep '^calico-node'",
+        environment => $env,
+      }
+    } else {
+      $shellsafe_provider = shell_escape($cni_network_provider)
+      exec { 'Install cni network provider':
+        command     => "kubectl apply -f ${shellsafe_provider}",
+        onlyif      => 'kubectl get nodes',
+        unless      => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|cilium)'",
+        environment => $env,
+      }
     }
   }
 

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -31,6 +31,29 @@ describe 'kubernetes::kube_addons', :type => :class do
     it { should contain_exec('Install calico rbac bindings')}
     it { should contain_exec('Install cni network provider')}
     it { should contain_exec('schedule on controller')}
+
+    it { should_not contain_exec('Install cni network (preinstall)')}
+    it { should_not contain_file('/etc/kubernetes/calico-installation.yaml')}
+    it { should_not contain_file_line('Configure calico ipPools.cidr')}
+  end
+
+  context 'with cni_provider => calico' do
+    let(:params) do {
+      'controller' => true,
+      'cni_network_preinstall' => 'https://foo.test/tigera-operator',
+      'cni_network_provider' => 'https://foo.test',
+      'cni_provider' => 'calico',
+      'install_dashboard' => false,
+      'dashboard_version' => 'v1.10.1',
+      'kubernetes_version' => '1.10.2',
+      'node_name' => 'foo',
+      }
+    end
+
+    it { should contain_exec('Install cni network (preinstall)')}
+    it { should contain_file('/etc/kubernetes/calico-installation.yaml')}
+    it { should contain_file_line('Configure calico ipPools.cidr')}
+    it { should contain_exec('Install cni network provider')}
   end
 
   context 'with install_dashboard => false' do

--- a/tooling/kube_tool.rb
+++ b/tooling/kube_tool.rb
@@ -33,7 +33,7 @@ parser = OptionParser.new do|opts|
   opts.on('-c', '--cni-provider cni-provider', 'the networking provider to use, flannel, weave, calico or cilium are supported') do |cni_provider|
     options[:cni_provider] = cni_provider;
   end
-  opts.on('-p', '--cni-provider-version [cni_provider_version]', 'the networking provider version to use, calico and cilium will use this to reference the correct deployment downloadlink') do |cni_provider_version|
+  opts.on('-p', '--cni-provider-version [cni_provider_version]', 'the networking provider version to use, cilium will use this to reference the correct deployment download link') do |cni_provider_version|
     options[:cni_provider_version] = cni_provider_version;
   end
 

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -28,7 +28,8 @@ class OtherParams
        cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'
        cni_pod_cidr = '10.244.0.0/16'
     elsif cni_provider.match('calico')
-       cni_network_provider = "https://docs.projectcalico.org/v#{cni_provider_version}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml"
+       cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"
+       cni_network_provider = "https://docs.projectcalico.org/manifests/custom-resources.yaml"
        cni_pod_cidr = '192.168.0.0/16'
     elsif cni_provider.match('cilium')
       cni_pod_cidr = '10.244.0.0/16'
@@ -68,8 +69,12 @@ class OtherParams
     data['kubernetes::kubernetes_version'] = version
     data['kubernetes::kubernetes_package_version'] = kubernetes_package_version
     data['kubernetes::container_runtime'] = container_runtime
+    if cni_network_preinstall
+      data['kubernetes::cni_network_preinstall'] = cni_network_preinstall
+    end
     data['kubernetes::cni_network_provider'] = cni_network_provider
     data['kubernetes::cni_pod_cidr'] = cni_pod_cidr
+    data['kubernetes::cni_provider'] = cni_provider
     data['kubernetes::etcd_initial_cluster'] = etcd_initial_cluster
     data['kubernetes::etcd_peers'] = etcd_peers
     data['kubernetes::etcd_ip'] = etcd_ip


### PR DESCRIPTION
Resolves #469

Recent releases of Calico (>=3.15) seem to prefer being installed with the Tigera operator.  This commit handles that.

cni_pod_cidr is also injected into the Installation object, as Calico and Tigera seem to ignore the networking.podSubnet set within the kubeadm-config ConfigMap.