### PR TITLE
gives the possibility to choose registry mirrors for containerd

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ The download URL for the containerd archive.
 
 Defaults to `https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive}`.
 
+#### `containerd_plugins_registry_mirrors`
+
+Specifies custom mirrors registry.
+
+An example in hiera:
+```
+kubernetes::containerd_plugins_registry_mirrors:
+  docker.elastic.co: https://artifact-docker-remote.lapin.lapine.net
+  k8s.gcr.io: https://artifact-docker-remote.lapin.lapine.net
+```
+Defaults `undef`
+
 #### `controller_address`
 
 The IP address and port for the controller the worker node joins. For example `172.17.10.101:6443`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,12 @@
 #  The URL to download the containerd archive
 #  Defaults to https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive}
 #
+# [*containerd_plugins_registry_mirrors*]
+# If you want custom plugins mirrors.
+#   An example with hiera would be kubernetes::containerd_plugins_registry_mirrors:
+#                                   docker.elastic.co: https://artifact-docker-remote.lapin.lapine.net
+# Defaults Undef
+#
 # [*dns_domain*]
 #   This is a string that sets the dns domain in kubernetes cluster
 #   Default cluster.local
@@ -574,6 +580,7 @@ class kubernetes (
   Optional[String] $containerd_archive_checksum                  = undef,
   Optional[String] $containerd_source                            =
     "https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive}",
+  Optional[Hash] $containerd_plugins_registry_mirrors            = undef,
   String $etcd_archive                                           = "etcd-v${etcd_version}-linux-amd64.tar.gz",
   Optional[String] $etcd_archive_checksum                        = undef,
   String $etcd_package_name                                      = 'etcd-server',

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -20,6 +20,7 @@ class kubernetes::packages (
   Optional[String] $containerd_archive                  = $kubernetes::containerd_archive,
   Optional[String] $containerd_archive_checksum         = $kubernetes::containerd_archive_checksum,
   Optional[String] $containerd_source                   = $kubernetes::containerd_source,
+  Optional[Hash] $containerd_plugins_registry_mirrors   = $kubernetes::containerd_plugins_registry_mirrors,
   String $etcd_archive                                  = $kubernetes::etcd_archive,
   Optional[String] $etcd_archive_checksum               = $kubernetes::etcd_archive_checksum,
   String $etcd_version                                  = $kubernetes::etcd_version,

--- a/templates/containerd/config.toml.erb
+++ b/templates/containerd/config.toml.erb
@@ -90,8 +90,15 @@ oom_score = 0
       conf_template = ""
     [plugins."io.containerd.grpc.v1.cri".registry]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+      <%- if @containerd_plugins_registry_mirrors -%>
+        <%- @containerd_plugins_registry_mirrors.keys.sort.each do |mirror| -%>
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."<%= mirror %>"]
+          endpoint = ["<%= @containerd_plugins_registry_mirrors[mirror] %>"]
+        <%- end -%>
+      <%- else -%>
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
+      <%- end -%>
     [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
       tls_cert_file = ""
       tls_key_file = ""


### PR DESCRIPTION
We wanted to be able to define our own mirrors.
Only registry-1.docker.io not being enough.