### PR TITLE
Update criSocket to avoid deprecation warnings

### DIFF
--- a/templates/v1alpha3/config_kubeadm.yaml.erb
+++ b/templates/v1alpha3/config_kubeadm.yaml.erb
@@ -15,7 +15,7 @@ kind: InitConfiguration
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
   kubeletExtraArgs:
     cgroup-driver: <%= @cgroup_driver %>
@@ -99,7 +99,7 @@ clusterName: <%= @kubernetes_cluster_name %>
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
   kubeletExtraArgs:
     cgroup-driver: <%= @cgroup_driver %>

--- a/templates/v1alpha3/config_worker.yaml.erb
+++ b/templates/v1alpha3/config_worker.yaml.erb
@@ -23,7 +23,7 @@ token: <%= @token %>
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
   kubeletExtraArgs:
     cgroup-driver: <%= @cgroup_driver %>

--- a/templates/v1beta1/config_kubeadm.yaml.erb
+++ b/templates/v1beta1/config_kubeadm.yaml.erb
@@ -15,7 +15,7 @@ localAPIEndpoint:
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
   kubeletExtraArgs:
     cgroup-driver: <%= @cgroup_driver %>

--- a/templates/v1beta1/config_worker.yaml.erb
+++ b/templates/v1beta1/config_worker.yaml.erb
@@ -13,7 +13,7 @@ discovery:
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
   kubeletExtraArgs:
     cgroup-driver: <%= @cgroup_driver %>

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -14,7 +14,7 @@ localAPIEndpoint:
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
   taints:
   - effect: NoSchedule

--- a/templates/v1beta2/config_worker.yaml.erb
+++ b/templates/v1beta2/config_worker.yaml.erb
@@ -16,7 +16,7 @@ discovery:
 nodeRegistration:
   name: <%= @node_name %>
   <%- if @container_runtime == "cri_containerd" -%>
-  criSocket: /run/containerd/containerd.sock
+  criSocket: unix:///run/containerd/containerd.sock
   taints: null
   <%- end -%>
   kubeletExtraArgs:


### PR DESCRIPTION
With Kubernetes 1.19.4 this is message I get when I restart kubelet:

```
Jan 21 14:37:33 kubecontroller-dev kubelet: W0121 14:37:33.169859   53934 util_unix.go:103] Using "/run/containerd/containerd.sock" as endpoint is deprecated, please consider using full url format "unix:///run/containerd/containerd.sock".
```