### PR TITLE
(IAC-995) - Removal of Inappropriate Terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-kubernetes.svg?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-kubernetes)
+[![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-kubernetes.svg?branch=main)](https://travis-ci.org/puppetlabs/puppetlabs-kubernetes)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppetlabs/kubernetes.svg)](https://forge.puppetlabs.com/puppetlabs/kubernetes)
 [![Puppet Forge Downloads](http://img.shields.io/puppetforge/dt/puppetlabs/kubernetes.svg)](https://forge.puppetlabs.com/puppetlabs/kubernetes)
 
@@ -26,7 +26,7 @@
 src="https://github.com/cncf/artwork/blob/04763c0f5f72b23d6a20bfc9c68c88cee805dbcc/projects/kubernetes/certified-kubernetes/1.13/color/certified-kubernetes-1.13-color.png"
 align="right" width="150px" alt="certified kubernetes 1.13">][certified]
 
-[certified]: https://github.com/cncf/k8s-conformance/tree/master/v1.13/puppetlabs-kubernetes
+[certified]: https://github.com/cncf/k8s-conformance/tree/main/v1.13/puppetlabs-kubernetes
 
 This module installs and configures [Kubernetes](https://kubernetes.io/) which is an open-source system for automating deployment, scaling, and management of containerized applications. For efficient management and discovery, containers that make up an application are grouped into logical units.
 
@@ -39,7 +39,7 @@ To bootstrap a Kubernetes cluster in a secure and extensible way, this module us
 
 [Install](https://puppet.com/docs/puppet/5.5/modules_installing.html) this module, [generate the configuration](#generating-the-module-configuration), [add the OS and hostname yaml files to Hiera](#adding-the-`{$OS}.yaml`-and-`{$hostname}.yaml`-files-to-Hiera), and [configure your node](#configuring-your-node).
 
-Included in this module is [Kubetool](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/master/tooling/kube_tool.rb), a configuration tool that auto-generates the Hiera security parameters, the discovery token hash, and other configurations for your Kubernetes cluster. To simplify installation and use, the tool is available as a Docker image.
+Included in this module is [Kubetool](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/main/tooling/kube_tool.rb), a configuration tool that auto-generates the Hiera security parameters, the discovery token hash, and other configurations for your Kubernetes cluster. To simplify installation and use, the tool is available as a Docker image.
 
 ### Generating the module configuration
 
@@ -58,7 +58,7 @@ docker run --rm -v $(pwd):/mnt --env-file env puppet/kubetool:{$module_version}
 The `docker run` command above includes an `env` file which is included in the root folder of this repo.
 
 ```
-docker run --rm -v $(pwd):/mnt -e OS=ubuntu -e VERSION=1.10.2 -e CONTAINER_RUNTIME=docker -e CNI_PROVIDER=cilium -e CNI_PROVIDER_VERSION=1.4.3 -e ETCD_INITIAL_CLUSTER=kube-master:172.17.10.101,kube-replica-master-01:172.17.10.210,kube-replica-master-02:172.17.10.220 -e ETCD_IP="%{networking.ip}" -e KUBE_API_ADVERTISE_ADDRESS="%{networking.ip}" -e INSTALL_DASHBOARD=true puppet/kubetool:{$module-version}
+docker run --rm -v $(pwd):/mnt -e OS=ubuntu -e VERSION=1.10.2 -e CONTAINER_RUNTIME=docker -e CNI_PROVIDER=cilium -e CNI_PROVIDER_VERSION=1.4.3 -e ETCD_INITIAL_CLUSTER=kube-control-plane:172.17.10.101,kube-replica-control-plane-01:172.17.10.210,kube-replica-control-plane-02:172.17.10.220 -e ETCD_IP="%{networking.ip}" -e KUBE_API_ADVERTISE_ADDRESS="%{networking.ip}" -e INSTALL_DASHBOARD=true puppet/kubetool:{$module-version}
 ```
 
 The above parameters are:
@@ -475,7 +475,7 @@ Defaults to `undef`.
 
 Informs etcd on how many nodes are in the cluster.
 
-A Hiera example is `kubernetes::etcd_initial_cluster: kube-master:172.17.10.101,kube-replica-master-01:172.17.10.210,kube-replica-master-02:172.17.10.220`.
+A Hiera example is `kubernetes::etcd_initial_cluster: kube-control-plane:172.17.10.101,kube-replica-control-plane-01:172.17.10.210,kube-replica-control-plane-02:172.17.10.220`.
 
 Defaults to `undef`.
 
@@ -616,7 +616,7 @@ Defaults to `{}`.
 
 #### `kubelet_extra_arguments`
 
-A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration. It is applied to both masters and nodes. Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config and DynamicKubeletConfig.
+A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration. It is applied to both control-planes and nodes. Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config and DynamicKubeletConfig.
 
 Defaults to `[]`.
 
@@ -710,7 +710,7 @@ Defaults to `undef`.
 
 #### `schedule_on_controller`
 
-Specifies whether to remove the master role and allow pod scheduling on controllers.
+Specifies whether to remove the control plane role and allow pod scheduling on controllers.
 
 Valid values are `true`, `false`.
 
@@ -754,7 +754,7 @@ Docker is the supported container runtime for this module.
 
 ## Development
 
-If you would like to contribute to this module, please follow the rules in the [CONTRIBUTING.md](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/master/CONTRIBUTING.md). For more information, see our [module contribution guide.](https://puppet.com/docs/puppet/latest/contributing.html)
+If you would like to contribute to this module, please follow the rules in the [CONTRIBUTING.md](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/main/CONTRIBUTING.md). For more information, see our [module contribution guide.](https://puppet.com/docs/puppet/latest/contributing.html)
 
 To run the acceptance tests you can use Puppet Litmus with the Vagrant provider by using the following commands:
 ```
@@ -791,4 +791,4 @@ As currently Litmus does not allow memory size and cpu size parameters for the V
 
 ## Examples
 
-In the examples folder you will find a [bash script](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/master/examples/task_examples.sh) containg a few sample Puppet Bolt commands for the usage of the tasks. The example script is intended to be used with a Kubernetes API that requires the token authentication header, but the token parameter is optional by default.  
+In the examples folder you will find a [bash script](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/main/examples/task_examples.sh) containg a few sample Puppet Bolt commands for the usage of the tasks. The example script is intended to be used with a Kubernetes API that requires the token authentication header, but the token parameter is optional by default.  

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -734,7 +734,7 @@ the files if they do not exist.
 
 [*etcd_initial_cluster*]
    This will tell etcd how many nodes will be in the cluster and is passed as a string.
-  An example with hiera would be kubernetes::etcd_initial_cluster: etcd-kube-master=http://172.17.10.101:2380,etcd-kube-replica-master-01=http://172.17.10.210:2380,etcd-kube-replica-master-02=http://172.17.10.220:2380
+  An example with hiera would be kubernetes::etcd_initial_cluster: etcd-kube-control-plane=http://172.17.10.101:2380,etcd-kube-replica-control-plane-01=http://172.17.10.210:2380,etcd-kube-replica-control-plane-02=http://172.17.10.220:2380
   Defaults to undef
 
 [*etcd_initial_cluster_state*]
@@ -870,7 +870,7 @@ the files if they do not exist.
   Defaults to v1.10.1
 
 [*schedule_on_controller*]
-  A flag to remove the master role and allow pod scheduling on controllers
+  A flag to remove the control plane role and allow pod scheduling on controllers
   Defaults to true
 
 [*service_cidr*]
@@ -905,7 +905,7 @@ the files if they do not exist.
  Defaults to {}
 
 [*kubelet_extra_arguments*]
- A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both masters and nodes.
+ A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both control planes and nodes.
  Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config
  Defaults to []
 
@@ -28316,7 +28316,7 @@ preferredVersion is the version preferred by the API server, which probably is t
 
 Data type: `Optional[String[1]]`
 
-a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.
+a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the control plane will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.
 
 ### `swagger_k8s_get_apiextensions_api_group`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,7 +167,7 @@
 #
 # [*etcd_initial_cluster*]
 #    This will tell etcd how many nodes will be in the cluster and is passed as a string.
-#   An example with hiera would be kubernetes::etcd_initial_cluster: etcd-kube-master=http://172.17.10.101:2380,etcd-kube-replica-master-01=http://172.17.10.210:2380,etcd-kube-replica-master-02=http://172.17.10.220:2380
+#   An example with hiera would be kubernetes::etcd_initial_cluster: etcd-kube-control-plane=http://172.17.10.101:2380,etcd-kube-replica-control-plane-01=http://172.17.10.210:2380,etcd-kube-replica-control-plane-02=http://172.17.10.220:2380
 #   Defaults to undef
 #
 # [*etcd_initial_cluster_state*]
@@ -303,7 +303,7 @@
 #   Defaults to v1.10.1
 #
 # [*schedule_on_controller*]
-#   A flag to remove the master role and allow pod scheduling on controllers
+#   A flag to remove the control plane role and allow pod scheduling on controllers
 #   Defaults to true
 #
 # [*service_cidr*]
@@ -338,7 +338,7 @@
 #  Defaults to {}
 #
 # [*kubelet_extra_arguments*]
-#  A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both masters and nodes.
+#  A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both control planes and nodes.
 #  Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config
 #  Defaults to []
 #

--- a/spec/defines/kubeadm_init_spec.rb
+++ b/spec/defines/kubeadm_init_spec.rb
@@ -23,7 +23,7 @@ describe 'kubernetes::kubeadm_init', :type => :define do
     let(:params) do
       {
         'config' => '/etc/kubernetes/config.yaml',
-        'node_name' => 'kube-master',
+        'node_name' => 'kube-control-plane',
         'path' => [ '/bin','/usr/bin','/sbin'],
         'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
       }
@@ -37,7 +37,7 @@ describe 'kubernetes::kubeadm_init', :type => :define do
     let(:params) do
       {
         'config' => '/etc/kubernetes/config.yaml',
-        'node_name' => 'kube-master',
+        'node_name' => 'kube-control-plane',
         'path' => [ '/bin','/usr/bin','/sbin'],
         'dry_run' => true,
         'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],
@@ -52,7 +52,7 @@ describe 'kubernetes::kubeadm_init', :type => :define do
     let(:params) do
       {
         'config' => '/etc/kubernetes/config.yaml',
-        'node_name' => 'kube-master',
+        'node_name' => 'kube-control-plane',
         'path' => [ '/bin','/usr/bin','/sbin'],
         'ignore_preflight_errors' => ['foo', 'bar'],
         'env' => [ 'KUBECONFIG=/etc/kubernetes/admin.conf'],

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -39,10 +39,10 @@ RSpec.configure do |c|
    run_shell('puppet module install puppetlabs-docker')
 
 hosts_file = <<-EOS
-127.0.0.1 localhost #{vmhostname} kubernetes kube-master
+127.0.0.1 localhost #{vmhostname} kubernetes kube-control-plane
 #{vmipaddr} #{vmhostname}
 #{vmipaddr} kubernetes
-#{vmipaddr} kube-master
+#{vmipaddr} kube-control-plane
       EOS
 
       nginx = <<-EOS

--- a/tasks/swagger_k8s_get_api_versions.json
+++ b/tasks/swagger_k8s_get_api_versions.json
@@ -50,7 +50,7 @@
 			,
 		    
 			"serveraddressbyclientcidrs":{
-			   "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+			   "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the control plane will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
 			   "type": "Optional[String[1]]"
 			}
 			


### PR DESCRIPTION
Removal of any offensive or inappropriate terminology from the code base.
References towards `node-role.kubernetes.io/master-` and `kubernetes::taint_master` have been left as I am unsure if they can/should be removed.