### PR TITLE
Add note about the kubernetes version format

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker run --rm -v $(pwd):/mnt -e OS=ubuntu -e VERSION=1.10.2 -e CONTAINER_RUNTI
 The above parameters are:
 
 * `OS`: The operating system Kubernetes runs on.
-* `VERSION`: The version of Kubernetes to deploy.
+* `VERSION`: The version of Kubernetes to deploy. Must follow X.Y.Z format. ([Check kubeadm regex rule](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/version.go#L43) for more information)
 * `CONTAINER_RUNTIME`: The container runtime Kubernetes uses. Set this value to `docker` (officially supported) or `cri_containerd`. Advanced Kubernetes users can use `cri_containerd`, however this requires an increased understanding of Kubernetes, specifically when running applications in a HA cluster. To run a HA cluster and access your applications, an external load balancer is required in front of your cluster. Setting this up is beyond the scope of this module. For more information, see the Kubernetes [documentation](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
 * `CNI_PROVIDER`: The CNI network to install. Set this value to `weave`, `flannel`, `calico` or `cilium`.
 * `CNI_PROVIDER_VERSION` The CNI version to use. `cilium` uses this variable to reference the correct deployment file. Current version `cilium` is `1.4.3`
@@ -592,7 +592,7 @@ Defaults to `undef`.
 
 #### `kubernetes_version`
 
-The version of the Kubernetes containers to install.
+The version of the Kubernetes containers to install. Must follow X.Y.Z format.
 
 Defaults to  `1.10.2`.
 


### PR DESCRIPTION
I was specifying `1.20` and I was getting this error.
```
kubeadm init --config '/etc/kubernetes/config.yaml' --ignore-preflight-errors='Service-Docker,' --v=5
I0223 17:24:54.964143   20131 initconfiguration.go:201] loading configuration from "/etc/kubernetes/config.yaml"
version "v1.20" doesn't match patterns for neither semantic version nor labels (stable, latest, ...)
```

Took me a while to figure out what was wrong. 
This PR improves the docs in that regard,