### PR TITLE
(maint) add parameters to accept different provisioning type

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         echo STEP_ID=setup-environment >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Checkout Source
       uses: actions/checkout@v2
       if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -42,12 +43,14 @@ jobs:
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
+
     - name: "Honeycomb: Record Setup Environment time"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
         echo STEP_ID=Setup-Integration-Test-Matrix >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Setup Integration Test Matrix
       id: get-matrix
       run: |
@@ -56,10 +59,12 @@ jobs:
         else
           echo  "::set-output name=matrix::{}"
         fi
+
     - name: "Honeycomb: Record Setup Test Matrix time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
+
   Integration:
     needs:
       - setup_matrix
@@ -116,35 +121,33 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
     - name: Provision test environment
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::provision_cluster gcp_image=${{ matrix.platform }}
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::provision_cluster image_type=${{ matrix.platform }}
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo
         echo ::endgroup::
         echo ::group::=== INVENTORY ===
-        sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ]; then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+        elif [ -f 'inventory.yaml' ]; then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
-    - name: Disable gpg check google-cloud.repo
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        retry_wait_seconds: 60
-        command: buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes::disable_gpg' -- bundle exec bolt --modulepath spec/fixtures/modules command run "sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/google-cloud.repo" --targets '*' -i ./inventory.yaml
+        echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
+
     - name: Puppet server setup
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::puppetserver_setup -i ./inventory.yaml
+        buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::puppetserver_setup collection='${{ matrix.collection }}' -i ./$INVENTORY_PATH
+
     - name: Install agent
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        retry_wait_seconds: 60
-        command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+      run:  |
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
 
     - name: Install module
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'
+
     - name: "Honeycomb: Record deployment times"
       if: ${{ always() }}
       run: |
@@ -157,23 +160,26 @@ jobs:
     - name: Run integration tests
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes:integration' -- bundle exec rake kubernetes:integration
+
     - name: "Honeycomb: Record integration testing times"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Run integration tests'
         echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Remove test environment
       if: ${{ always() }}
       continue-on-error: true
       run: |
-        if [ -f inventory.yaml ]; then
+        if [ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]; then
           buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
           echo ::group::=== REQUEST ===
           cat request.json || true
           echo
           echo ::endgroup::
         fi
+
     - name: "Honeycomb: Record removal times"
       if: ${{ always() }}
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         echo STEP_ID=setup-environment >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Checkout Source
       uses: actions/checkout@v2
       if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -44,12 +45,14 @@ jobs:
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
+
     - name: "Honeycomb: Record Setup Environment time"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
         echo STEP_ID=Setup-Integration-Test-Matrix >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Setup Integration Test Matrix
       id: get-matrix
       run: |
@@ -58,10 +61,12 @@ jobs:
         else
           echo  "::set-output name=matrix::{}"
         fi
+
     - name: "Honeycomb: Record Setup Test Matrix time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
+
   Integration:
     needs:
       - setup_matrix
@@ -118,28 +123,33 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
     - name: Provision test environment
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::provision_cluster gcp_image=${{ matrix.platform }}
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::provision_cluster image_type=${{ matrix.platform }}
         echo ::group::=== REQUEST ===
         cat request.json || true
         echo
         echo ::endgroup::
         echo ::group::=== INVENTORY ===
-        sed -e 's/password: .*/password: "[redacted]"/' < inventory.yaml || true
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ]; then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+        elif [ -f 'inventory.yaml' ]; then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
         echo ::endgroup::
-    - name: Install module
+        echo INVENTORY_PATH=$FILE >> $GITHUB_ENV
+
+    - name: Puppet server setup
       run: |
-        buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::puppetserver_setup -i ./inventory.yaml
+        buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes::puppetserver_setup' -- bundle exec bolt --modulepath spec/fixtures/modules plan run kubernetes::puppetserver_setup collection='${{ matrix.collection }}' -i ./$INVENTORY_PATH
+
     - name: Install agent
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        retry_wait_seconds: 60
-        command: buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+      run:  |
+        buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_agent ${{ matrix.collection }}' -- bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
 
     - name: Install module
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'
+
     - name: "Honeycomb: Record deployment times"
       if: ${{ always() }}
       run: |
@@ -152,23 +162,26 @@ jobs:
     - name: Run integration tests
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake kubernetes:integration' -- bundle exec rake kubernetes:integration
+
     - name: "Honeycomb: Record integration testing times"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Run integration tests'
         echo STEP_ID=${{ matrix.platform }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
     - name: Remove test environment
       if: ${{ always() }}
       continue-on-error: true
       run: |
-        if [ -f inventory.yaml ]; then
+        if [ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]; then
           buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
           echo ::group::=== REQUEST ===
           cat request.json || true
           echo
           echo ::endgroup::
         fi
+
     - name: "Honeycomb: Record removal times"
       if: ${{ always() }}
       run: |

--- a/plans/provision_cluster.pp
+++ b/plans/provision_cluster.pp
@@ -3,15 +3,16 @@
 # Provisions machines for integration testing
 #
 # @example
-#   kubernetes::provision_integration
+#   kubernetes::provision_cluster
 plan kubernetes::provision_cluster(
-  Optional[String] $gcp_image = 'centos-7',
+  Optional[String] $image_type = 'centos-7',
+  Optional[String] $provision_type = 'provision_service',
 ) {
   #provision server machine, set role
-  run_task('provision::provision_service', 'localhost',
-    action => 'provision', platform => $gcp_image, vars => 'role: controller')
-  run_task('provision::provision_service', 'localhost',
-    action => 'provision', platform => $gcp_image, vars => 'role: worker1')
-  run_task('provision::provision_service', 'localhost',
-    action => 'provision', platform => $gcp_image, vars => 'role: worker2')
+  run_task("provision::$provision_type", 'localhost',
+    action => 'provision', platform => $image_type, vars => 'role: controller')
+  run_task("provision::$provision_type", 'localhost',
+    action => 'provision', platform => $image_type, vars => 'role: worker1')
+  run_task("provision::$provision_type", 'localhost',
+    action => 'provision', platform => $image_type, vars => 'role: worker2')
 }

--- a/plans/puppetserver_setup.pp
+++ b/plans/puppetserver_setup.pp
@@ -1,9 +1,25 @@
+# @summary Provisions machines
+#
+# Puppet Server Setup
+#
+# @example
+#   kubernetes::puppetserver_setup
 plan kubernetes::puppetserver_setup(
+  Optional[String] $collection = 'puppet7-nightly'
 ) {
   $puppet_server =  get_targets('*').filter |$n| { $n.vars['role'] == 'controller' }
-  $puppet_server_string = $puppet_server[0].name
-  # install pe server
-  run_task('provision::install_puppetserver', $puppet_server)
+
+  # get facts
+  $puppet_server_facts = facts($puppet_server[0])
+  $platform = $puppet_server_facts['platform']
+
+  # install puppet server
+  run_task(
+    'provision::install_puppetserver',
+    $puppet_server,
+    'install and configure server',
+    { 'collection' => $collection, 'platform' => $platform }
+  )
 }
 
 

--- a/spec/acceptance/integration_kubernetes_spec.rb
+++ b/spec/acceptance/integration_kubernetes_spec.rb
@@ -45,10 +45,11 @@ describe 'we are able to setup a controller and workers', :integration do
     after(:all) { reset_target_host }
     describe 'verify the k8 nodes' do
       it 'verify the k8 nodes' do
+        run_shell('sleep 20')
         run_shell('KUBECONFIG=/etc/kubernetes/admin.conf kubectl get nodes') do |r|
-          expect(r.stdout).to match(/#{hostname1}   Ready    master/)
-          expect(r.stdout).to match(/#{hostname2}   Ready/)
-          expect(r.stdout).to match(/#{hostname3}   Ready/)
+          expect(r.stdout).to match(/#{hostname1}(\s)+Ready(\s)+master/)
+          expect(r.stdout).to match(/#{hostname2}(\s)+Ready/)
+          expect(r.stdout).to match(/#{hostname3}(\s)+Ready/)
         end
       end
     end


### PR DESCRIPTION
Add parameters to accept different provisioning type
By adding this parameter will help to test on gcp/abs etc
Modifies tests to match spaces in output
Modified workflows to remove reference to non-puppetlabs repo
Modified puppet server plans wrt the new changes
Modified plans to accommodate the inventory file location

ABS Results
`Running acceptance test on woolen-chimney with address woolen-chimney.delivery.puppetlabs.net and OS centos-7-x86_64

we are able to setup a controller and workers
  set up the controller
    set up controller
      sets up the controller
  set up the worker1
    set up worker
      sets up the worker
  set up the worker2
    set up worker
      sets up the worker
  verify the k8 nodes
    verify the k8 nodes
      verify the k8 nodes

the Kubernetes module
  clean up before each test
    kubernetes class
      it should install the module and run
        should run
        should install kubectl
        should install kube-dns
      application deployment
        can deploy an application into a namespace and expose it
        can access the deployed service
        can delete a deployment

Finished in 8 minutes 48 seconds (files took 19.87 seconds to load)
10 examples, 0 failures

➜  puppetlabs-kubernetes git:(k8local) ✗`