### PR TITLE
Support both standard Calico and Calico Tigera

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The above parameters are:
 * `VERSION`: The version of Kubernetes to deploy. Must follow X.Y.Z format. ([Check kubeadm regex rule](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/version.go#L43) for more information)
 * `CONTAINER_RUNTIME`: The container runtime Kubernetes uses. Set this value to `docker` (officially supported) or `cri_containerd`. Advanced Kubernetes users can use `cri_containerd`, however this requires an increased understanding of Kubernetes, specifically when running applications in a HA cluster. To run a HA cluster and access your applications, an external load balancer is required in front of your cluster. Setting this up is beyond the scope of this module. For more information, see the Kubernetes [documentation](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/).
 * `CNI_PROVIDER`: The CNI network to install. Set this value to `weave`, `flannel`, `calico` or `cilium`.
-* `CNI_PROVIDER_VERSION` The CNI version to use. `cilium` uses this variable to reference the correct deployment file. Current version `cilium` is `1.4.3`
+* `CNI_PROVIDER_VERSION` The CNI version to use. `calico` and `cilium` uses this variable to reference the correct deployment file. Current version `cilium` is `1.4.3`, calico is `3.18`
 * `ETCD_INITIAL_CLUSTER`: The server hostnames and IPs in the form of `hostname:ip`. When in production, include three, five, or seven nodes for etcd.
 * `ETCD_IP`: The IP each etcd member listens on. We recommend passing the fact for the interface to be used by the cluster.
 * `KUBE_API_ADVERTISE_ADDRESS`: The IP each etcd/apiserver instance uses on each controller. We recommend passing the fact for the interface to be used by the cluster.

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -35,7 +35,7 @@ class kubernetes::kube_addons (
   }
 
   if $cni_network_provider {
-    if $cni_provider == 'calico' {
+    if $cni_provider == 'calico-tigera' {
       if $cni_network_preinstall {
         $shellsafe_preinstall = shell_escape($cni_network_preinstall)
         exec { 'Install cni network (preinstall)':
@@ -72,7 +72,7 @@ class kubernetes::kube_addons (
       exec { 'Install cni network provider':
         command     => "kubectl apply -f ${shellsafe_provider}",
         onlyif      => 'kubectl get nodes',
-        unless      => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|cilium)'",
+        unless      => "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'",
         environment => $env,
       }
     }

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -40,9 +40,28 @@ describe 'kubernetes::kube_addons', :type => :class do
   context 'with cni_provider => calico' do
     let(:params) do {
       'controller' => true,
-      'cni_network_preinstall' => 'https://foo.test/tigera-operator',
       'cni_network_provider' => 'https://foo.test',
       'cni_provider' => 'calico',
+      'install_dashboard' => false,
+      'dashboard_version' => 'v1.10.1',
+      'kubernetes_version' => '1.10.2',
+      'node_name' => 'foo',
+      }
+    end
+
+    it { should contain_exec('Install cni network provider')}
+
+    it { should_not contain_exec('Install cni network (preinstall)')}
+    it { should_not contain_file('/etc/kubernetes/calico-installation.yaml')}
+    it { should_not contain_file_line('Configure calico ipPools.cidr')}
+  end
+
+  context 'with cni_provider => calico-tigera' do
+    let(:params) do {
+      'controller' => true,
+      'cni_network_preinstall' => 'https://foo.test/tigera-operator',
+      'cni_network_provider' => 'https://foo.test',
+      'cni_provider' => 'calico-tigera',
       'install_dashboard' => false,
       'dashboard_version' => 'v1.10.1',
       'kubernetes_version' => '1.10.2',

--- a/tooling/kube_tool.rb
+++ b/tooling/kube_tool.rb
@@ -33,7 +33,7 @@ parser = OptionParser.new do|opts|
   opts.on('-c', '--cni-provider cni-provider', 'the networking provider to use, flannel, weave, calico or cilium are supported') do |cni_provider|
     options[:cni_provider] = cni_provider;
   end
-  opts.on('-p', '--cni-provider-version [cni_provider_version]', 'the networking provider version to use, cilium will use this to reference the correct deployment download link') do |cni_provider_version|
+  opts.on('-p', '--cni-provider-version [cni_provider_version]', 'the networking provider version to use, calico and cilium will use this to reference the correct deployment download link') do |cni_provider_version|
     options[:cni_provider_version] = cni_provider_version;
   end
 

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -31,6 +31,9 @@ class OtherParams
        cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"
        cni_network_provider = "https://docs.projectcalico.org/manifests/custom-resources.yaml"
        cni_pod_cidr = '192.168.0.0/16'
+    elsif cni_provider.match('calico-tigera')
+       cni_network_provider = "https://docs.projectcalico.org/archive/#{cni_provider_version}/manifests/calico.yaml"
+       cni_pod_cidr = '192.168.0.0/16'
     elsif cni_provider.match('cilium')
       cni_pod_cidr = '10.244.0.0/16'
       if container_runtime.match('docker')

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -28,11 +28,11 @@ class OtherParams
        cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'
        cni_pod_cidr = '10.244.0.0/16'
     elsif cni_provider.match('calico')
-       cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"
-       cni_network_provider = "https://docs.projectcalico.org/manifests/custom-resources.yaml"
+       cni_network_provider = "https://docs.projectcalico.org/archive/#{cni_provider_version}/manifests/calico.yaml"
        cni_pod_cidr = '192.168.0.0/16'
     elsif cni_provider.match('calico-tigera')
-       cni_network_provider = "https://docs.projectcalico.org/archive/#{cni_provider_version}/manifests/calico.yaml"
+       cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"
+       cni_network_provider = "https://docs.projectcalico.org/manifests/custom-resources.yaml"
        cni_pod_cidr = '192.168.0.0/16'
     elsif cni_provider.match('cilium')
       cni_pod_cidr = '10.244.0.0/16'


### PR DESCRIPTION
#473 is not the right way to install Calico since the previous deployment method before that change was to deploy the on-premise YAML which installs the daemon sets to `kube-system` namespace which is still valid with all recent versions: https://docs.projectcalico.org/getting-started/kubernetes/self-managed-onprem/onpremises.

The Tigera install is documented as the "quickstart" method: https://docs.projectcalico.org/getting-started/kubernetes/quickstart but is not where close to what used to be previous behavior of this module.

If this solution of changing to using `calico-tigera` is not preferred let me know and I can adjust maybe to make the namespace dynamic.  But the whole idea of modifying a file line from YAML is 100% not needed for on premise deployments of Calico which is the behavior that existed before #473