### PR TITLE
Allow configuring of waiting times during sa creation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1223,6 +1223,8 @@ The following parameters are available in the `kubernetes` class:
 * [`conntrack_tcp_wait_timeout`](#conntrack_tcp_wait_timeout)
 * [`conntrack_tcp_stablished_timeout`](#conntrack_tcp_stablished_timeout)
 * [`tmp_directory`](#tmp_directory)
+* [`wait_for_default_sa_tries`](#wait_for_default_sa_tries)
+* [`wait_for_default_sa_try_sleep`](#wait_for_default_sa_try_sleep)
 
 ##### <a name="kubernetes_version"></a>`kubernetes_version`
 
@@ -2213,6 +2215,22 @@ Data type: `String`
 
 
 Default value: `'/var/tmp/puppetlabs-kubernetes'`
+
+##### <a name="wait_for_default_sa_tries"></a>`wait_for_default_sa_tries`
+
+Data type: `Integer`
+
+
+
+Default value: `5`
+
+##### <a name="wait_for_default_sa_try_sleep"></a>`wait_for_default_sa_try_sleep`
+
+Data type: `Integer`
+
+
+
+Default value: `6`
 
 ### <a name="kubernetescluster_roles"></a>`kubernetes::cluster_roles`
 
@@ -4070,7 +4088,7 @@ Data type: `Optional[Integer]`
 
 
 
-Default value: `5`
+Default value: `$kubernetes::wait_for_default_sa_tries`
 
 ##### <a name="try_sleep"></a>`try_sleep`
 
@@ -4078,7 +4096,7 @@ Data type: `Optional[Integer]`
 
 
 
-Default value: `6`
+Default value: `$kubernetes::wait_for_default_sa_try_sleep`
 
 ##### <a name="env"></a>`env`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -677,6 +677,8 @@ class kubernetes (
   String $conntrack_tcp_wait_timeout                             = '1h0m0s',
   String $conntrack_tcp_stablished_timeout                       = '24h0m0s',
   String $tmp_directory                                          = '/var/tmp/puppetlabs-kubernetes',
+  Integer $wait_for_default_sa_tries                             = 5,
+  Integer $wait_for_default_sa_try_sleep                         = 6,
 ) {
   if !$facts['os']['family'] in ['Debian', 'RedHat'] {
     notify { "The OS family ${facts['os']['family']} is not supported by this module": }

--- a/manifests/wait_for_default_sa.pp
+++ b/manifests/wait_for_default_sa.pp
@@ -3,8 +3,8 @@ define kubernetes::wait_for_default_sa (
   String $namespace            = $title,
   Array $path                  = $kubernetes::default_path,
   Optional[Integer] $timeout   = undef,
-  Optional[Integer] $tries     = 5,
-  Optional[Integer] $try_sleep = 6,
+  Optional[Integer] $tries     = $kubernetes::wait_for_default_sa_tries,
+  Optional[Integer] $try_sleep = $kubernetes::wait_for_default_sa_try_sleep,
   Optional[Array] $env         = $kubernetes::environment,
 ) {
   $safe_namespace = shell_escape($namespace)


### PR DESCRIPTION
The currently hardcoded parameters for the number of tries and sleep duration work for most setups. However, in some slower environments (like Vagrant), 30 sec is not enough to create a service account.

This change allows configuring `$wait_for_default_sa_tries` and `$wait_for_default_sa_try_sleep` so that they could be adjusted to a particular situation if needed.