### PR TITLE
Support for kubernetes dashboard version 2.0.0 and onwards

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -328,11 +328,11 @@
 #
 # [*kubernetes_dashboard_url*]
 #   The URL to get the Kubernetes Dashboard yaml file.
-#   Defaults to the upstream source. `kube_tool` sets this value.
+#   Default is based on dashboard_version.
 #
 # [*dashboard_version*]
 #   The version of Kubernetes dashboard you want to install.
-#   Defaults to v1.10.1
+#   Defaults to 1.10.1
 #
 # [*schedule_on_controller*]
 #   A flag to remove the control plane role and allow pod scheduling on controllers
@@ -579,9 +579,8 @@ class kubernetes (
   Optional[String] $cni_provider                                 = undef,
   Optional[String] $cni_rbac_binding                             = undef,
   Boolean $install_dashboard                                     = false,
-  String $dashboard_version                                      = 'v1.10.1',
-  String $kubernetes_dashboard_url                               =
-    "https://raw.githubusercontent.com/kubernetes/dashboard/${dashboard_version}/src/deploy/recommended/kubernetes-dashboard.yaml",
+  String $dashboard_version                                      = '1.10.1',
+  String $kubernetes_dashboard_url                               = undef,
   Boolean $schedule_on_controller                                = false,
   Integer $api_server_count                                      = undef,
   Boolean $delegated_pki                                         = false,
@@ -682,6 +681,12 @@ class kubernetes (
 ) {
   if !$facts['os']['family'] in ['Debian', 'RedHat'] {
     notify { "The OS family ${facts['os']['family']} is not supported by this module": }
+  }
+
+  if versioncmp($dashboard_version, '2.0.0') >= 0 {
+    $dashboard_url = pick($kubernetes_dashboard_url, "https://raw.githubusercontent.com/kubernetes/dashboard/v${dashboard_version}/aio/deploy/recommended.yaml")
+  } else {
+    $dashboard_url = pick($kubernetes_dashboard_url, "https://raw.githubusercontent.com/kubernetes/dashboard/v${dashboard_version}/src/deploy/recommended/kubernetes-dashboard.yaml")
   }
 
   # Some cloud providers override or fix the node name, so we can't override

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -580,7 +580,7 @@ class kubernetes (
   Optional[String] $cni_rbac_binding                             = undef,
   Boolean $install_dashboard                                     = false,
   String $dashboard_version                                      = '1.10.1',
-  String $kubernetes_dashboard_url                               = undef,
+  Optional[String] $kubernetes_dashboard_url                     = undef,
   Boolean $schedule_on_controller                                = false,
   Integer $api_server_count                                      = undef,
   Boolean $delegated_pki                                         = false,

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -8,8 +8,8 @@ class kubernetes::kube_addons (
   Optional[String] $cni_rbac_binding        = $kubernetes::cni_rbac_binding,
   Boolean $install_dashboard                = $kubernetes::install_dashboard,
   String $dashboard_version                 = $kubernetes::dashboard_version,
+  String $dashboard_url                     = $kubernetes::dashboard_url,
   String $kubernetes_version                = $kubernetes::kubernetes_version,
-  String $kubernetes_dashboard_url          = $kubernetes::kubernetes_dashboard_url,
   Boolean $controller                       = $kubernetes::controller,
   Optional[Boolean] $schedule_on_controller = $kubernetes::schedule_on_controller,
   String $node_name                         = $kubernetes::node_name,
@@ -86,7 +86,7 @@ class kubernetes::kube_addons (
   }
 
   if $install_dashboard {
-    $shellsafe_source = shell_escape($kubernetes_dashboard_url)
+    $shellsafe_source = shell_escape($dashboard_url)
     exec { 'Install Kubernetes dashboard':
       command     => "kubectl apply -f ${shellsafe_source}",
       onlyif      => 'kubectl get nodes',

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -21,7 +21,6 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_rbac_binding' => 'foo',
       'cni_network_provider' => 'https://foo.test',
       'install_dashboard' => false,
-      'dashboard_version' => 'v1.10.1',
       'kubernetes_version' => '1.10.2',
       'schedule_on_controller' => true,
       'node_name' => 'foo',
@@ -43,7 +42,6 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_network_provider' => 'https://foo.test',
       'cni_provider' => 'calico',
       'install_dashboard' => false,
-      'dashboard_version' => 'v1.10.1',
       'kubernetes_version' => '1.10.2',
       'node_name' => 'foo',
       }
@@ -63,7 +61,6 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_network_provider' => 'https://foo.test',
       'cni_provider' => 'calico-tigera',
       'install_dashboard' => false,
-      'dashboard_version' => 'v1.10.1',
       'kubernetes_version' => '1.10.2',
       'node_name' => 'foo',
       }
@@ -82,7 +79,6 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_network_provider' => 'https://foo.test',
       'install_dashboard' => false,
       'kubernetes_version' => '1.10.2',
-      'dashboard_version' => 'v1.10.1',
       'schedule_on_controller' => false,
       'node_name' => 'foo',
       }
@@ -97,7 +93,7 @@ describe 'kubernetes::kube_addons', :type => :class do
       'cni_network_provider' => 'https://foo.test',
       'install_dashboard' => true,
       'kubernetes_version' => '1.10.2',
-      'dashboard_version' => 'v1.10.1',
+      'dashboard_version' => '1.10.1',
       'schedule_on_controller' => false,
       'node_name' => 'foo',
       }


### PR DESCRIPTION
Fix for https://github.com/puppetlabs/puppetlabs-kubernetes/issues/421

The URL changed after v2.0.0 this is why it was not working.

This patch is backwards compatible in case someone still wants to use old versions of the dashboard.

Thanks.