### PR TITLE
Enable live-restore for Docker daemon.

### DIFF
--- a/templates/docker/daemon_debian.json.erb
+++ b/templates/docker/daemon_debian.json.erb
@@ -1,5 +1,6 @@
 {
   "exec-opts": ["native.cgroupdriver=<%= @docker_cgroup_driver %>"],
+  "live-restore": true,
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "<%= @docker_log_max_size %>",

--- a/templates/docker/daemon_redhat.json.erb
+++ b/templates/docker/daemon_redhat.json.erb
@@ -1,5 +1,6 @@
 {
   "exec-opts": ["native.cgroupdriver=<%= @docker_cgroup_driver %>"],
+  "live-restore": true,
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "<%= @docker_log_max_size %>",


### PR DESCRIPTION
The live restore option helps reduce container downtime due to daemon crashes, planned outages, or upgrades. By default, when the Docker daemon terminates, it shuts down running containers. This option allows to keep all containers running.