### PR TITLE
Remove cgroup-driver arg to avoid deprecation warnings

### DIFF
--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -259,9 +259,6 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it 'has node_name==foo in first YAML document (InitConfig)' do
       expect(config_yaml[0]['nodeRegistration']).to include('name' => params['node_name'])
     end
-    it 'has cgroup-driver==cgroupfs in first YAML document (InitConfig) NodeRegistration' do
-      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).to include('cgroup-driver' => 'cgroupfs')
-    end
     it 'has cloud-provider==aws in first YAML document (InitConfig) NodeRegistration' do
       expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).to include('cloud-provider' => params['cloud_provider'])
     end
@@ -286,9 +283,6 @@ describe 'kubernetes::config::kubeadm', :type => :class do
 
     it 'has API Server extra volumes in YAML document' do
       expect(config_yaml[1]).to include('apiServerExtraVolumes')
-    end
-    it 'has cgroup-driver==systemd in first YAML document (InitConfig) NodeRegistration' do
-      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).to include('cgroup-driver' => 'systemd')
     end
   end
 

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -20,7 +20,6 @@ nodeRegistration:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
   kubeletExtraArgs:
-    cgroup-driver: <%= @cgroup_driver %>
     <%- if @cloud_provider -%>
     cloud-provider: <%= @cloud_provider %>
     <%- end -%>

--- a/templates/v1beta2/config_worker.yaml.erb
+++ b/templates/v1beta2/config_worker.yaml.erb
@@ -20,7 +20,6 @@ nodeRegistration:
   taints: null
   <%- end -%>
   kubeletExtraArgs:
-    cgroup-driver: <%= @cgroup_driver %>
     <%- if @cloud_provider -%>
     cloud-provider: <%= @cloud_provider %>
     <%- if @cloud_config -%>

--- a/templates/v1beta3/config_kubeadm.yaml.erb
+++ b/templates/v1beta3/config_kubeadm.yaml.erb
@@ -20,7 +20,6 @@ nodeRegistration:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
   kubeletExtraArgs:
-    cgroup-driver: <%= @cgroup_driver %>
     <%- if @cloud_provider -%>
     cloud-provider: <%= @cloud_provider %>
     <%- end -%>

--- a/templates/v1beta3/config_worker.yaml.erb
+++ b/templates/v1beta3/config_worker.yaml.erb
@@ -19,7 +19,6 @@ nodeRegistration:
   taints: null
   <%- end -%>
   kubeletExtraArgs:
-    cgroup-driver: <%= @cgroup_driver %>
     <%- if @cloud_provider -%>
     cloud-provider: <%= @cloud_provider %>
     <%- if @cloud_config -%>


### PR DESCRIPTION
This is the warning with Kubernetes 1.22.4:

```
kubelet: Flag --cgroup-driver has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
```