### PR TITLE
pdksync - (GH-iac-334) Remove Support for Ubuntu 16.04

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,9 +10,9 @@ fixtures:
     helm: 'puppetlabs-helm'
     rook: 'puppetlabs-rook'
   repositories:
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    provision: 'https://github.com/puppetlabs/provision.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+
       ]
     }
   ],


### PR DESCRIPTION
(GH-iac-334) Remove Support for Ubuntu 16.04
pdk version: `2.1.0` 
