### PR TITLE
Stop recurisve file mode change, restricted parent dirs

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -79,8 +79,8 @@ class kubernetes::config::kubeadm (
   $kube_dirs.each | String $dir | {
     file { $dir :
       ensure  => directory,
-      mode    => '0600',
-      recurse => true,
+      mode    => '0700',
+      recurse => false,
     }
   }
 

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -33,8 +33,8 @@ class kubernetes::config::worker (
 
   file { '/etc/kubernetes':
     ensure  => directory,
-    mode    => '0600',
-    recurse => true,
+    mode    => '0700',
+    recurse => false,
   }
 
   file { $config_file:


### PR DESCRIPTION
Prevents constant flipping of file modes, top-level restrictions suffice.

I noticed that our puppet env was constantly adjusting perms on files in the /etc/kubernetes directories.  While not useless, it was somewhat pointless in the case that the perms on the top-level directories should prevent any group/world access.  So the recursive mode is somewhat redundant or excessive imho.

Also, the perm was specified as 0600 on a directory, while puppet seems to have some workaround for making this 700 for dirs by default (I couldn't find the code), it seems a little less explicit on desired perms.

fwiw, it was nvidia gpu-feature-discovery that always creates its files world-readable / 644 that caused me to notice this.