### PR TITLE
Add proxy support to docker, cri_containerd and kubelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ Valid values are `cri_containerd` or `docker`.
 
 Defaults to `docker`.
 
+#### `container_runtime_use_proxy`
+
+When set to true will cause the new proxy variables to be applied to the container runtime. Currently only implemented for Docker.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`.
+
 #### `controller`
 
 Specifies whether to set the node as a Kubernetes controller.
@@ -634,6 +642,18 @@ The peer certificate key data for the etcd cluster. This value must be passed as
 
 Defaults to `undef`.
 
+#### `http_proxy`
+
+The string value to set for the HTTP_PROXY environment variable.
+
+Defaults to `undef`.
+
+#### `https_proxy`
+
+The string value to set for the HTTPS_PROXY environment variable.
+
+Defaults to `undef`.
+
 #### image_repository
 
 The container registry to pull control plane images from.
@@ -740,6 +760,14 @@ The URL for the APT repo gpg key.
 
 Defaults to `https://packages.cloud.google.com/apt/doc/apt-key.gpg`.
 
+#### `kubelet_use_proxy`
+
+When set to true will cause the new proxy variables to be applied to the Kubelet.
+
+Valid values are `true`, `false`.
+
+Defaults to `false`.
+
 #### `kubernetes_yum_baseurl`
 
 The YUM repo URL for the Kubernetes packages.
@@ -767,6 +795,12 @@ Specifies whether to install an external Etcd via this module.
 Valid values are `true`, `false`.
 
 Defaults to `true`.
+
+#### `no_proxy`
+
+The string value to set for the NO_PROXY environment variable.
+
+Defaults to `undef`.
 
 #### `node_label`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -533,6 +533,30 @@
 #   {'RootlessControlPlane' => true}
 # Default: undefined, no feature gates
 #
+# [*http_proxy*]
+#  Configure the HTTP_PROXY environment variable
+#  Defaults to undef
+#
+# [*https_proxy*]
+#  Configure the HTTPS_PROXY environment variable
+#  Defaults to undef
+#
+# [*no_proxy*]
+#  Configure the NO_PROXY environment variable
+#  Defaults to undef
+#
+# [*container_runtime_use_proxy*]
+#  Configure whether the container runtime should be configured to use a proxy.
+#  If set to true, the container runtime will use the http_proxy, https_proxy and
+#  no_proxy values.
+#  Defaults to false
+#
+# [*kubelet_use_proxy*]
+#  Configure whether the kubelet should be configured to use a proxy.
+#  If set to true, the kubelet will use the http_proxy, https_proxy and
+#  no_proxy values.
+#  Defaults to false
+#
 # Authors
 # -------
 #
@@ -662,6 +686,11 @@ class kubernetes (
     default  => undef,
   },
   Optional[String] $docker_extra_daemon_config            = undef,
+  Optional[String] $http_proxy                            = undef,
+  Optional[String] $https_proxy                           = undef,
+  Optional[String] $no_proxy                              = undef,
+  Boolean $container_runtime_use_proxy                    = false,
+  Boolean $kubelet_use_proxy                              = false,
   String $docker_log_max_file                             = '1',
   String $docker_log_max_size                             = '100m',
   Boolean $disable_swap                                   = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -576,10 +576,7 @@ class kubernetes (
   Enum['archive','package'] $containerd_install_method    = 'archive',
   String $containerd_package_name                         = 'containerd.io',
   String $docker_package_name                             = 'docker-engine',
-  Optional[String] $docker_version                        = $facts['os']['family'] ? {
-    'Debian' => '5:20.10.11~3-0~ubuntu-' + $facts['os']['distro']['codename'],
-    'RedHat' => '17.03.1.ce-1.el7.centos',
-  },
+  Optional[String] $docker_version                        = undef,
   Boolean $pin_packages                                   = false,
   String $dns_domain                                      = 'cluster.local',
   Optional[String] $cni_pod_cidr                          = undef,

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -52,7 +52,7 @@ describe 'kubernetes::repos', :type => :class do
 
     it { should contain_apt__source('docker').with(
       :ensure   => 'present',
-      :location => 'https://apt.dockerproject.org/repo',
+      :location => 'https://download.docker.com/linux/ubuntu',
       :repos    => 'main',
       :release  => 'xenial',
       :key      => { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/ubuntu/gpg' }
@@ -109,7 +109,7 @@ describe 'kubernetes::repos', :type => :class do
 
     it { should contain_apt__source('docker').with(
       :ensure   => 'present',
-      :location => 'https://apt.dockerproject.org/repo',
+      :location => 'https://download.docker.com/linux/ubuntu',
       :repos    => 'main',
       :release  => 'xenial',
       :key      => { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/ubuntu/gpg' }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -142,4 +142,49 @@ describe 'kubernetes::service', :type => :class do
     end
     it { is_expected.to_not contain_file('/etc/systemd/system/kubelet.service.d/20-cloud.conf')}
   end
+
+  context 'with container_runtime => cri_containerd and container_runtime_use_proxy => true' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.10.2',
+        'container_runtime' => 'cri_containerd',
+        'container_runtime_use_proxy' => true,
+        'http_proxy' => 'foo',
+        'https_proxy' => 'bar',
+        'no_proxy' => 'baz',
+        'controller' => true,
+        'cloud_provider' => '',
+        'cloud_config' => '',
+        'manage_docker' => true,
+        'manage_etcd' => true,
+      }
+    end
+    it { should contain_file('/etc/systemd/system/containerd.service.d')}
+    it { should contain_file('/etc/systemd/system/containerd.service.d/http-proxy.conf').with_content(/\s*Environment="HTTP_PROXY=foo"\s*/)}
+    it { should contain_file('/etc/systemd/system/containerd.service.d/http-proxy.conf').with_content(/\s*Environment="HTTPS_PROXY=bar"\s*/)}
+    it { should contain_file('/etc/systemd/system/containerd.service.d/http-proxy.conf').with_content(/\s*Environment="NO_PROXY=baz"\s*/)}
+    it { should_not contain_file('/etc/systemd/system/docker.service.d/http-proxy.conf')}
+  end
+
+  context 'with kubelet_use_proxy => true' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.10.2',
+        'container_runtime' => 'cri_containerd',
+        'kubelet_use_proxy' => true,
+        'http_proxy' => 'foo',
+        'https_proxy' => 'bar',
+        'no_proxy' => 'baz',
+        'controller' => true,
+        'cloud_provider' => '',
+        'cloud_config' => '',
+        'manage_docker' => true,
+        'manage_etcd' => true,
+      }
+    end
+    it { should contain_file('/etc/systemd/system/kubelet.service.d')}
+    it { should contain_file('/etc/systemd/system/kubelet.service.d/http-proxy.conf').with_content(/\s*Environment="HTTP_PROXY=foo"\s*/)}
+    it { should contain_file('/etc/systemd/system/kubelet.service.d/http-proxy.conf').with_content(/\s*Environment="HTTPS_PROXY=bar"\s*/)}
+    it { should contain_file('/etc/systemd/system/kubelet.service.d/http-proxy.conf').with_content(/\s*Environment="NO_PROXY=baz"\s*/)}
+  end
 end

--- a/templates/http-proxy.conf.erb
+++ b/templates/http-proxy.conf.erb
@@ -1,0 +1,10 @@
+[Service]
+<%- if @http_proxy != '' -%>
+Environment="HTTP_PROXY=<%= @http_proxy -%>"
+<%- end -%>
+<%- if @http_proxy != '' -%>
+Environment="HTTPS_PROXY=<%= @https_proxy -%>"
+<%- end -%>
+<%- if @http_proxy != '' -%>
+Environment="NO_PROXY=<%= @no_proxy -%>"
+<%- end -%>


### PR DESCRIPTION
This PR adds the ability to configure proxying for the container runtime and Kubelet.
    
    Add 3 new string variables - http_proxy, https_proxy and no_proxy.

    [*http_proxy*]
     Configure the HTTP_PROXY environment variable

    [*https_proxy*]
     Configure the HTTPS_PROXY environment variable

    [*no_proxy*]
     Configure the NO_PROXY environment variable

    Add a boolean 'container_runtime_use_proxy' which when set to true will cause
    the new proxy variables to be applied to the container runtime.

    [*container_runtime_use_proxy*]
     Configure whether the container runtime should be configured to use a proxy.
     If set to true, the container runtime will use the http_proxy, https_proxy and
     no_proxy values.

    Add a boolean 'kubelet_use_proxy' which when set to true will cause the
    http_proxy, https_proxy and no_proxy variables to be applied to the kubelet.

    [*kubelet_use_proxy*]
     Configure whether the kubelet should use a proxy. If set to true, the kubelet
     will use the http_proxy, https_proxy and no_proxy values