### PR TITLE
Don't try to guess docker_version (#564)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -552,10 +552,7 @@ class kubernetes (
   Enum['archive','package'] $containerd_install_method    = 'archive',
   String $containerd_package_name                         = 'containerd.io',
   String $docker_package_name                             = 'docker-engine',
-  Optional[String] $docker_version                        = $facts['os']['family'] ? {
-    'Debian' => '5:20.10.11~3-0~ubuntu-' + $facts['os']['distro']['codename'],
-    'RedHat' => '17.03.1.ce-1.el7.centos',
-  },
+  Optional[String] $docker_version                        = undef,
   Boolean $pin_packages                                   = false,
   String $dns_domain                                      = 'cluster.local',
   Optional[String] $cni_pod_cidr                          = undef,

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -52,7 +52,7 @@ describe 'kubernetes::repos', :type => :class do
 
     it { should contain_apt__source('docker').with(
       :ensure   => 'present',
-      :location => 'https://apt.dockerproject.org/repo',
+      :location => 'https://download.docker.com/linux/ubuntu',
       :repos    => 'main',
       :release  => 'xenial',
       :key      => { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/ubuntu/gpg' }
@@ -109,7 +109,7 @@ describe 'kubernetes::repos', :type => :class do
 
     it { should contain_apt__source('docker').with(
       :ensure   => 'present',
-      :location => 'https://apt.dockerproject.org/repo',
+      :location => 'https://download.docker.com/linux/ubuntu',
       :repos    => 'main',
       :release  => 'xenial',
       :key      => { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/ubuntu/gpg' }


### PR DESCRIPTION
This PR should fix rspec tests that are currently failing (incorrect expectations).

Guessing `docker_version` for RedHat and Debian systems isn't very helpful.