### PR TITLE
Support Debian 11

### DIFF
--- a/data/os/Debian/11.yaml
+++ b/data/os/Debian/11.yaml
@@ -1,0 +1,2 @@
+---
+kubernetes::cgroup_driver: systemd

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,16 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-
+        "18.04",
+        "20.04",
+        "22.04"
+      ]
+    },
+     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10",
+        "11"
       ]
     }
   ],

--- a/templates/containerd/config.toml.erb
+++ b/templates/containerd/config.toml.erb
@@ -94,6 +94,9 @@ oom_score = 0
           privileged_without_host_devices = false
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+<%- if @docker_cgroup_driver == 'systemd' -%>
+            SystemdCgroup = true
+<%- end -%>
 <%- if @containerd_default_runtime_name == 'nvidia' -%>
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
           runtime_type = "io.containerd.runc.v2"


### PR DESCRIPTION
On Debian 11 the [recommended cgroups driver](https://github.com/containerd/containerd/blob/main/docs/cri/config.md) is `systemd` however the `systemdCgroups` parameter is required otherwise one will encounter [weird issues](https://github.com/kubernetes/website/issues/33795).