### PR TITLE
Master role has been deprecated since kubernetes v1.20.0

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -173,6 +173,13 @@ class kubernetes::config::kubeadm (
     default                  => 'v1beta3',
   }
 
+  # master role is DEPRECATED
+  if versioncmp($kubernetes_version, '1.20.0') >= 0 {
+    $node_role = 'control-plane'
+  } else {
+    $node_role = 'master'
+  }
+
   file { $config_file:
     ensure  => file,
     content => template("kubernetes/${config_version}/config_kubeadm.yaml.erb"),

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -555,4 +555,19 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       expect(config_yaml[2]['conntrack']['tcpEstablishedTimeout']).to eq('0h0m0s')
     end
   end
+
+  context 'set role control-plane' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.20.0',
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it {
+      is_expected.to contain_file('/etc/kubernetes/config.yaml') \
+        .with_content(%r{key: node-role.kubernetes.io/control-plane\n})
+    }
+  end
 end

--- a/templates/v1beta2/config_kubeadm.yaml.erb
+++ b/templates/v1beta2/config_kubeadm.yaml.erb
@@ -18,7 +18,7 @@ nodeRegistration:
   <%- end -%>
   taints:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
+    key: node-role.kubernetes.io/<%= @node_role %>
   kubeletExtraArgs:
     <%- if @cloud_provider -%>
     cloud-provider: <%= @cloud_provider %>


### PR DESCRIPTION
`master` role [has been deprecated](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#urgent-upgrade-notes):

> Introduce a new label "node-role.kubernetes.io/control-plane" that will be applied in parallel to "node-role.kubernetes.io/master" until the removal of the "node-role.kubernetes.io/master" label.


