### PR TITLE
Switch containerd grpc socket to URI

### DIFF
--- a/templates/containerd/config.toml.erb
+++ b/templates/containerd/config.toml.erb
@@ -7,7 +7,7 @@ required_plugins = []
 oom_score = 0
 
 [grpc]
-  address = "/run/containerd/containerd.sock"
+  address = "unix:///run/containerd/containerd.sock"
   tcp_address = ""
   tcp_tls_cert = ""
   tcp_tls_key = ""


### PR DESCRIPTION
Adjusts the `containerd` configuration to properly address the `containerd` socket via URI; fixes deprecation warnings when using `crictl` on nodes.