### PR TITLE
Add RedHat family as supported OS (#563)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,11 +48,17 @@
         "22.04"
       ]
     },
-     {
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
         "11"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
       ]
     }
   ],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,99 +1,94 @@
 require 'spec_helper'
-describe 'kubernetes', :type => :class do
-  let(:facts) do
-    {
-      :osfamily         => 'Debian', #needed to run dependent tests from fixtures puppetlabs-apt
-      :kernel           => 'Linux',
-      :os               => {
-        :family => 'Debian',
-        :name    => 'Ubuntu',
-        :release => {
-          :full => '16.04',
-        },
-        :distro => {
-          :codename => "xenial",
-        },
-      },
-      :ec2_metadata     => {
-        :hostname => 'ip-10-10-10-1.ec2.internal',
-      },
-    }
-  end
+describe 'kubernetes' do
 
-  context 'with controller => true and worker => true' do
-    let(:params) do {
-      :controller => true,
-      :worker => true,
-    } end
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts.merge({
+          :ec2_metadata => {
+            :hostname => 'ip-10-10-10-1.ec2.internal',
+          }
+        })
+      end
 
-    it { should compile.and_raise_error(/A node can not be both a controller and a node/) }
-   end
+      it { is_expected.to compile }
 
-  context 'with controller => true' do
+      context 'with controller => true and worker => true' do
+        let(:params) do {
+          controller: true,
+          worker: true,
+        } end
 
-    let(:params) do {
-      :controller => true,
-    } end
+        it { is_expected.to raise_error(/A node can not be both a controller and a node/) }
+       end
 
-    it { should contain_class('kubernetes') }
-    it { should contain_class('kubernetes::repos') }
-    it { should contain_class('kubernetes::packages')}
-    it { should contain_class('kubernetes::config::kubeadm')}
-    it { should contain_class('kubernetes::service')}
-    it { should contain_class('kubernetes::cluster_roles')}
-    it { should contain_class('kubernetes::kube_addons')}
-  end
+      context 'with controller => true' do
 
-  context 'with worker => true and version => 1.10.2' do
-    let(:params) do {
-      :worker => true,
-    } end
-                
-    it { should contain_class('kubernetes') }
-    it { should contain_class('kubernetes::repos') }
-    it { should contain_class('kubernetes::packages')}
-    it { is_expected.to_not contain_class('kubernetes::config::kubeadm')}
-    it { is_expected.to_not contain_class('kubernetes::config::worker')}
-    it { should contain_class('kubernetes::service')}
-  end
+        let(:params) do {
+          controller: true,
+        } end
 
-  context 'with worker => true and version => 1.12.2' do
-    let(:params) do {
-      :worker => true,
-      :kubernetes_version => '1.12.2',
-    } end
-                
-    it { is_expected.to_not contain_class('kubernetes::config::kubeadm')}
-    it { is_expected.to contain_class('kubernetes::config::worker')}
-  end
+        it { is_expected.to contain_class('kubernetes') }
+        it { is_expected.to contain_class('kubernetes::repos') }
+        it { is_expected.to contain_class('kubernetes::packages')}
+        it { is_expected.to contain_class('kubernetes::config::kubeadm')}
+        it { is_expected.to contain_class('kubernetes::service')}
+        it { is_expected.to contain_class('kubernetes::cluster_roles')}
+        it { is_expected.to contain_class('kubernetes::kube_addons')}
+      end
 
-  context 'with node_label => foo and cloud_provider => undef' do
-    let(:params) do {
-      :worker => true,
-      :node_label => 'foo',
-      :cloud_provider => :undef,
-    } end
-                
-    it { is_expected.to_not contain_notify('aws_node_name') }
-  end
+      context 'with worker => true and version => 1.10.2' do
+        let(:params) do {
+          worker: true,
+        } end
 
-  context 'with node_label => foo and cloud_provider => aws' do
-    let(:params) do {
-      :worker => true,
-      :node_label => 'foo',
-      :cloud_provider => 'aws',
-    } end
+        it { is_expected.to contain_class('kubernetes') }
+        it { is_expected.to contain_class('kubernetes::repos') }
+        it { is_expected.to contain_class('kubernetes::packages')}
+        it { is_expected.to_not contain_class('kubernetes::config::kubeadm')}
+        it { is_expected.to_not contain_class('kubernetes::config::worker')}
+        it { is_expected.to contain_class('kubernetes::service')}
+      end
 
-    it { is_expected.to contain_notify('aws_name_override') }
-  end
+      context 'with worker => true and version => 1.12.2' do
+        let(:params) do {
+          worker:  true,
+          kubernetes_version: '1.12.2',
+        } end
 
-  context 'with node_label => undef and cloud_provider => aws' do
-    let(:params) do {
-      :worker => true,
-      :node_label => :undef,
-      :cloud_provider => 'aws',
-    } end
+        it { is_expected.to_not contain_class('kubernetes::config::kubeadm')}
+        it { is_expected.to contain_class('kubernetes::config::worker')}
+      end
 
-    it { is_expected.to_not contain_notify('aws_name_override') }
+      context 'with node_label => foo and cloud_provider => undef' do
+        let(:params) do {
+          worker: true,
+          node_label: 'foo',
+          cloud_provider: :undef,
+        } end
+
+        it { is_expected.to_not contain_notify('aws_node_name') }
+      end
+
+      context 'with node_label => foo and cloud_provider => aws' do
+        let(:params) do {
+          worker: true,
+          node_label: 'foo',
+          cloud_provider: 'aws',
+        } end
+
+        it { is_expected.to contain_notify('aws_name_override') }
+      end
+
+      context 'with node_label => undef and cloud_provider => aws' do
+        let(:params) do {
+          worker: true,
+          node_label: :undef,
+          cloud_provider: 'aws',
+        } end
+
+        it { is_expected.to_not contain_notify('aws_name_override') }
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR refactor spec so that at least the basic tests executed for each supported OS family.

This might catch in the future some basic errors when `metadata.json` is changed.

Goolge's YUM repos currently doesn't support newer RedHat releases. Though at least RedHat 7 is definitely supported.