### PR TITLE
pdksync - (CONT-130) - Dropping Support for Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
         "22.04"
       ]
     },
-     {
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",


### PR DESCRIPTION
(CONT-130) - Dropping Support for Debian 9
pdk version: `2.4.0` 
