### PR TITLE
(CONT-217) Correct Kubernetes etcd_data_dir spec tests

### DIFF
--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -86,9 +86,6 @@ class kubernetes::config::kubeadm (
   }
 
   if $manage_etcd {
-    file { $etcd_data_dir:
-      ensure => file,
-    }
     if !$delegated_pki {
       $etcd.each | String $etcd_files | {
         file { "/etc/kubernetes/pki/etcd/${etcd_files}":

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -8,7 +8,7 @@ define kubernetes::kubeadm_init (
   Optional[Array] $ignore_preflight_errors      = $kubernetes::ignore_preflight_errors,
   Optional[String] $skip_phases                 = $kubernetes::skip_phases,
 ) {
-  $kubeadm_init_flags = kubeadm_init_flags( {
+  $kubeadm_init_flags = kubeadm_init_flags({
       config                  => $config,
       dry_run                 => $dry_run,
       ignore_preflight_errors => $ignore_preflight_errors,

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -19,7 +19,7 @@ define kubernetes::kubeadm_join (
   case $kubernetes_version {
     # K1.11 and below don't use the config file
     /^1.1(0|1)/: {
-      $kubeadm_join_flags = kubeadm_join_flags( {
+      $kubeadm_join_flags = kubeadm_join_flags({
           controller_address       => $controller_address,
           cri_socket               => $cri_socket,
           discovery_file           => $discovery_file,
@@ -34,7 +34,7 @@ define kubernetes::kubeadm_join (
       })
     }
     default: {
-      $kubeadm_join_flags = kubeadm_join_flags( {
+      $kubeadm_join_flags = kubeadm_join_flags({
           config                   => $config,
           discovery_file           => $discovery_file,
           feature_gates            => $feature_gates,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -63,11 +63,11 @@ class kubernetes::service (
       }
 
       file { '/etc/systemd/system/containerd.service.d':
-        ensure  => directory,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0755',
-        notify  => Exec['kubernetes-systemd-reload'],
+        ensure => directory,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
+        notify => Exec['kubernetes-systemd-reload'],
       }
 
       if $container_runtime_use_proxy {

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -60,7 +60,6 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo}) }
-    it { is_expected.to contain_file('/var/lib/etcd') }
 
     context 'with etcd_listen_metric_urls defined' do
       let(:params) do
@@ -74,17 +73,6 @@ describe 'kubernetes::config::kubeadm', :type => :class do
       end
 
       it { is_expected.to contain_file('/etc/systemd/system/etcd.service').with_content(%r{.*--listen-metrics-urls http://0.0.0.0:2381.*}) }
-    end
-
-    context 'with etcd_data_dir configured' do
-      let(:params) do
-        {
-          'manage_etcd' => true,
-          'etcd_data_dir' => '/var/lib/foo',
-        }
-      end
-
-      it { is_expected.to contain_file('/var/lib/foo' )}
     end
   end
 
@@ -179,6 +167,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_AUTO_COMPACTION_MODE=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_DISCOVERY_SRV=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_LISTEN_METRICS_URLS=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{ETCD_DATA_DIR="\/var\/lib\/etcd"}) }
 
     context 'with etcd_listen_metric_urls defined' do
       let(:params) do
@@ -197,7 +186,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     end
   end
 
-  context 'manage_etcd => true and etcd_install_method => package and etcd_discovery_srv => etcd-autodiscovery' do
+  context 'manage_etcd => true and etcd_install_method => package and etcd_discovery_srv => etcd-autodiscovery and etcd_data_dir => "/var/lib/foo"' do
     let(:params) do
       {
         'etcd_install_method' => 'package',
@@ -207,6 +196,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
         'manage_etcd' => true,
         'etcd_discovery_srv' => 'etcd-autodiscovery',
         'etcd_version' => '2.9.9',
+        'etcd_data_dir' => '/var/lib/foo',
       }
     end
 
@@ -215,6 +205,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_AUTO_COMPACTION_MODE=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_DISCOVERY_SRV="etcd-autodiscovery".*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{ETCD_DATA_DIR="\/var\/lib\/foo"}) }
   end
 
   context 'manage_etcd => true and etcd_install_method => wget and etcd_discovery_srv => etcd-autodiscovery' do
@@ -237,7 +228,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/systemd/system/etcd.service').without_content(%r{.*--auto-compaction-mode .*}) }
   end
 
-  context 'manage_etcd => true and etcd_install_method => package' do
+  context 'manage_etcd => true and etcd_install_method => package and etcd_data_dir => /var/lib/bar' do
     let(:params) do
       {
         'etcd_install_method' => 'package',
@@ -245,6 +236,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
         'kubelet_extra_config' => { 'baz' => ['bar', 'foo'] },
         'kubelet_extra_arguments' => ['foo'],
         'manage_etcd' => true,
+        'etcd_data_dir' => '/var/lib/bar',
       }
     end
 
@@ -252,6 +244,7 @@ describe 'kubernetes::config::kubeadm', :type => :class do
     it { is_expected.to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{.*ETCD_INITIAL_CLUSTER=.*}) }
     it { is_expected.to contain_file('/etc/default/etcd').without_content(%r{.*ETCD_DISCOVERY_SRV=.*}) }
+    it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{ETCD_DATA_DIR="\/var\/lib\/bar"}) }
   end
 
   context 'with version = 1.12 and node_name => foo and cloud_provider => aws' do


### PR DESCRIPTION
Removed incorrect functionality and test cases.
Added spec test to ensure that ETCD_DATA_DIR exists in the config file generated and ensures the default value of etcd_data_dir is its value
Additional tests will come with CONT-215