### PR TITLE
(MAINT) Fixing codebase hardening issues

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -42,7 +42,7 @@ class kubernetes::kube_addons (
       if $cni_network_preinstall {
         $preinstall_command = ['kubectl', 'apply', '-f', $cni_network_preinstall]
         $preinstall_onlyif = ['kubectl', 'get', 'nodes']
-        $preinstall_unless = ["kubectl -n tigera-operator get deployments | egrep '^tigera-operator'"]
+        $preinstall_unless = [["kubectl -n tigera-operator get deployments | egrep '^tigera-operator'"]]
 
         exec { 'Install cni network (preinstall)':
           command     => $preinstall_command,
@@ -56,7 +56,7 @@ class kubernetes::kube_addons (
       $calico_installation_path = '/etc/kubernetes/calico-installation.yaml'
       $path_command = ['kubectl', 'apply', '-f', '/etc/kubernetes/calico-installation.yaml']
       $path_onlyif = ['kubectl', 'get', 'nodes']
-      $path_unless = ["kubectl -n calico-system get daemonset | egrep '^calico-node'"]
+      $path_unless = [["kubectl -n calico-system get daemonset | egrep '^calico-node'"]]
 
       file { $calico_installation_path:
         ensure  => 'present',
@@ -81,7 +81,7 @@ class kubernetes::kube_addons (
     } else {
       $provider_command = ['kubectl', 'apply', '-f', $cni_network_provider]
       $provider_onlyif = ['kubectl', 'get', 'nodes']
-      $provider_unless = ["kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'"]
+      $provider_unless = [["kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'"]]
 
       exec { 'Install cni network provider':
         command     => $provider_command,
@@ -92,7 +92,7 @@ class kubernetes::kube_addons (
     }
   }
 
-  if $node_name !~ /^[a-zA-Z0-9\-_]+$/ {
+  if $node_name !~ /^[a-zA-Z0-9]([a-zA-Z0-9\-\.]{0,251}[a-zA-Z0-9])?$/ {
     fail("Invalid node name: ${node_name}")
   }
 

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -16,7 +16,7 @@ define kubernetes::kubeadm_init (
   })
 
   $exec_init = ['kubeadm', 'init', $kubeadm_init_flags]
-  $unless_init = ["kubectl get nodes | grep ${node_name}"]
+  $unless_init = [["kubectl get nodes | grep ${node_name}"]]
 
   exec { 'kubeadm init':
     command     => $exec_init,

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -44,7 +44,7 @@ define kubernetes::kubeadm_join (
   }
 
   $exec_join = ['kubeadm', 'join', $kubeadm_join_flags]
-  $unless_join = ["kubectl get nodes | grep ${node_name}"]
+  $unless_join = [["kubectl get nodes | grep ${node_name}"]]
 
   exec { 'kubeadm join':
     command     => $exec_join,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -60,7 +60,7 @@ class kubernetes::packages (
 
   if $disable_swap {
     $command = ['swapoff', '-a']
-    $unless = ['awk', '"{ if (NR > 1) exit 1}"', '/proc/swaps']
+    $unless = [['awk', '"{ if (NR > 1) exit 1}"', '/proc/swaps']]
 
     exec { 'disable swap':
       path    => ['/usr/sbin/', '/usr/bin', '/bin', '/sbin'],

--- a/manifests/wait_for_default_sa.pp
+++ b/manifests/wait_for_default_sa.pp
@@ -11,10 +11,11 @@ define kubernetes::wait_for_default_sa (
 
   # This prevents a known race condition https://github.com/kubernetes/kubernetes/issues/66689
   $cmd = ['kubectl', '-n', $safe_namespace, 'get', 'serviceaccount', 'default', '-o', 'name']
+  $unless_cmd = [['kubectl', '-n', $safe_namespace, 'get', 'serviceaccount', 'default', '-o', 'name']]
 
   exec { "wait for default serviceaccount creation in ${safe_namespace}":
     command     => $cmd,
-    unless      => $cmd,
+    unless      => $unless_cmd,
     path        => $path,
     environment => $env,
     timeout     => $timeout,

--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.5.0",


### PR DESCRIPTION
Prior to this commit, an issue arised for Kubernetes that confirmed some code regressions within the module after the Codebase Hardening update (CONT-8). After investigating the resulting regression, some errors in the sanitisation process were spotted.

This PR aims to address these errors produced during the hardening stage before properly investigating and addressing the current regression (CONT-272).

Note: This PR will initially be categorised as maintenance. However, it might be related to both CONT-272 / #585 and CONT-263.