### PR TITLE
(MAINT) Addressing wrong type for unless execs

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -42,7 +42,7 @@ class kubernetes::kube_addons (
       if $cni_network_preinstall {
         $preinstall_command = ['kubectl', 'apply', '-f', $cni_network_preinstall]
         $preinstall_onlyif = ['kubectl', 'get', 'nodes']
-        $preinstall_unless = [["kubectl -n tigera-operator get deployments | egrep '^tigera-operator'"]]
+        $preinstall_unless = "kubectl -n tigera-operator get deployments | egrep '^tigera-operator'"
 
         exec { 'Install cni network (preinstall)':
           command     => $preinstall_command,
@@ -56,7 +56,7 @@ class kubernetes::kube_addons (
       $calico_installation_path = '/etc/kubernetes/calico-installation.yaml'
       $path_command = ['kubectl', 'apply', '-f', '/etc/kubernetes/calico-installation.yaml']
       $path_onlyif = ['kubectl', 'get', 'nodes']
-      $path_unless = [["kubectl -n calico-system get daemonset | egrep '^calico-node'"]]
+      $path_unless = "kubectl -n calico-system get daemonset | egrep '^calico-node'"
 
       file { $calico_installation_path:
         ensure  => 'present',
@@ -81,7 +81,7 @@ class kubernetes::kube_addons (
     } else {
       $provider_command = ['kubectl', 'apply', '-f', $cni_network_provider]
       $provider_onlyif = ['kubectl', 'get', 'nodes']
-      $provider_unless = [["kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'"]]
+      $provider_unless = "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'"
 
       exec { 'Install cni network provider':
         command     => $provider_command,
@@ -98,7 +98,7 @@ class kubernetes::kube_addons (
 
   if $schedule_on_controller {
     $schedule_command = ['kubectl', 'taint', 'nodes', $node_name, 'node-role.kubernetes.io/master-']
-    $schedule_onlyif = ["kubectl describe nodes ${node_name} | tr -s ' ' | grep 'Taints: node-role.kubernetes.io/master:NoSchedule'"]
+    $schedule_onlyif = "kubectl describe nodes ${node_name} | tr -s ' ' | grep 'Taints: node-role.kubernetes.io/master:NoSchedule'"
 
     exec { 'schedule on controller':
       command => $schedule_command,

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -16,8 +16,7 @@ define kubernetes::kubeadm_init (
   })
 
   $exec_init = ['kubeadm', 'init', $kubeadm_init_flags]
-  $unless_init = [["kubectl get nodes | grep ${node_name}"]]
-
+  $unless_init = "kubectl get nodes | grep ${node_name}"
   exec { 'kubeadm init':
     command     => $exec_init,
     environment => $env,

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -44,7 +44,7 @@ define kubernetes::kubeadm_join (
   }
 
   $exec_join = ['kubeadm', 'join', $kubeadm_join_flags]
-  $unless_join = [["kubectl get nodes | grep ${node_name}"]]
+  $unless_join = "kubectl get nodes | grep ${node_name}"
 
   exec { 'kubeadm join':
     command     => $exec_join,


### PR DESCRIPTION
Prior to this commit, as part of codebase hardening, unless commands were wrapped in nested arrays so as to follow with proper convention. However, a bug is found where unless commands containing a pipe | will not work when broken down, nor when placed in a nested array.

This commit aims to revert some changes from the original codebase hardening to address the failing conditionals.