### PR TITLE
Rewrite command line arguments parsing

### DIFF
--- a/tooling/Dockerfile
+++ b/tooling/Dockerfile
@@ -10,9 +10,10 @@ RUN set -x && \
   git clone https://github.com/cloudflare/cfssl_trust.git /go/src/github.com/cloudflare/cfssl_trust && \
   echo "Build complete."
 
-FROM ruby:2.3.5-alpine
+FROM ruby:3.0-alpine3.16
 COPY --from=0 /go/src/github.com/cloudflare/cfssl_trust /etc/cfssl
 COPY --from=0 /go/src/github.com/cloudflare/cfssl/bin/ /usr/bin
+RUN gem install slop
 COPY . /etc/k8s
 
 RUN set -x && \
@@ -20,4 +21,4 @@ RUN set -x && \
 
 WORKDIR /mnt
 
-ENTRYPOINT ["sh", "-c", "/etc/k8s/start-kubetool.sh"]
+ENTRYPOINT ["ruby", "/etc/k8s/kube_tool.rb"]

--- a/tooling/kube_tool.rb
+++ b/tooling/kube_tool.rb
@@ -1,88 +1,64 @@
 #!/usr/bin/env ruby
 
-require 'optparse'
+require 'slop'
 require_relative 'kube_tool/pre_checks.rb'
 require_relative 'kube_tool/create_certs.rb'
 require_relative 'kube_tool/clean_up.rb'
 require_relative 'kube_tool/other_params.rb'
 
-options = {:os                         => nil,
-           :version                    => nil,
-           :container_runtime          => nil,
-           :cni_provider               => nil,
-           :cni_provider_version       => nil,
-           :etcd_initial_cluster       => nil,
-           :kube_api_advertise_address => nil,
-           :install_dashboard          => nil,
-           :key_size                   => nil,
-          }
-
-parser = OptionParser.new do|opts|
-
-  opts.on('-o', '--os-type os-type', 'the os that kubernetes will run on') do |os|
-    options[:os] = os;
-  end
-
-  opts.on('-v', '--version version', 'the kubernetes version to install') do |version|
-    options[:version] = version;
-  end
-
-  opts.on('-r', '--container_runtime container runtime', 'the container runtime to use. this can only be docker or cri_containerd') do |container_runtime|
-    options[:container_runtime] = container_runtime;
-  end
-
-  opts.on('-c', '--cni-provider cni-provider', 'the networking provider to use, flannel, weave, calico or cilium are supported') do |cni_provider|
-    options[:cni_provider] = cni_provider;
-  end
-  opts.on('-p', '--cni-provider-version [cni_provider_version]', 'the networking provider version to use, calico and cilium will use this to reference the correct deployment download link') do |cni_provider_version|
-    options[:cni_provider_version] = cni_provider_version;
-  end
-
-  opts.on('-i', '--etcd-initial-cluster etcd-initial-cluster', 'the list of servers in the etcd cluster') do | etcd_initial_cluster |
-    options[:etcd_initial_cluster] = etcd_initial_cluster
-  end
-
-  opts.on('-t', '--etcd-ip etcd_ip', 'ip address etcd will listen on') do |etcd_ip|
-    options[:etcd_ip] = etcd_ip;
-  end
-
-  opts.on('-a', '--api-address api_address', 'the ip address that kube api will listen on') do |api_address|
-    options[:kube_api_advertise_address] = api_address;
-  end
-
-  opts.on('-b', '--key-size key_size', 'Specifies the number of bits in the key to create') do |key_size|
-    options[:key_size] = key_size
-  end
-
-  opts.on('-d', '--install-dashboard dashboard', 'install the kube dashboard') do |dashboard|
-    options[:install_dashboard] = dashboard;
-  end
-
-  opts.on('-h', '--help', 'Displays Help') do
-    puts opts
-    exit
-  end
-end
-
-parser.parse!
-
-
 class Kube_tool
-  def build_hiera(hash)
-    key_size = hash[:key_size].to_i
-    OtherParams.create( hash[:os], hash[:version], hash[:container_runtime], hash[:cni_provider], hash[:cni_provider_version], hash[:etcd_initial_cluster], hash[:etcd_ip], hash[:kube_api_advertise_address], hash[:install_dashboard])
+  def self.parse_args
+    begin
+      opts = Slop.parse do |o|
+        o.string '-o', '--os', 'The OS that Kubernetes will run on', default: ENV['OS']
+        o.string '-v', '--version', 'The Kubernetes version to install', default: ENV['VERSION']
+        o.string '-r', '--container_runtime', 'The container runtime to use. This can only be "docker" or "cri_containerd"', default: ENV['CONTAINER_RUNTIME']
+        o.string '-c', '--cni_provider', 'The networking provider to use, flannel, weave, calico, calico-tigera or cilium are supported', default: ENV['CNI_PROVIDER']
+        o.string '-p', '--cni_provider_version', 'The networking provider version to use, calico and cilium will use this to reference the correct deployment download link', default: ENV['CNI_PROVIDER_VERSION']
+        o.string '-t', '--etcd_ip', 'The IP address etcd will listen on', default: ENV['ETCD_IP']
+        o.string '-i', '--etcd_initial_cluster', 'The list of servers in the etcd cluster', default: ENV['ETCD_INITIAL_CLUSTER']
+        o.string '-a', '--api_address', 'The IP address (or fact) that kube api will listen on', default: ENV['KUBE_API_ADVERTISE_ADDRESS']
+        o.int '-b', '--key_size', 'Specifies the number of bits in the key to create', default: ENV['KEY_SIZE'].to_i
+        o.int '--ca_algo', 'Algorithm to generate CA certificates, default: ecdsa', default: ENV['CA_ALGO']
+        o.int '--sa_size', 'Service account key size', default: ENV['SA_SIZE'].to_i
+        o.bool '-d', '--install_dashboard', 'Whether install the kube dashboard', default: ENV['INSTALL_DASHBOARD']
+        o.on '-h','--help', 'print the help' do
+          puts o
+          exit
+        end
+      end
+
+      options = opts.to_hash
+      options[:key_size] = 256 if options[:key_size] < 1
+      options[:sa_size] = 2048 if options[:sa_size] < 1
+      options[:ca_algo] ||= 'ecdsa'
+      options[:container_runtime] ||= 'cri_containerd'
+      options[:version] ||= '1.25.4'
+      options[:os] ||= 'Debian'
+      if options[:etcd_initial_cluster].nil?
+        abort('Please provide IP addresses for etcd initial cluster -i/--etcd_initial_cluster (ENV ETCD_INITIAL_CLUSTER)')
+      end
+      puts options
+      return options
+
+    rescue Slop::Error => e
+      puts "ERROR: #{e.message}"
+      exit 1
+    end
+  end
+
+  def self.build_hiera(opts)
+    OtherParams.create(opts)
     PreChecks.checks
-    CreateCerts.etcd_ca(key_size)
-    CreateCerts.etcd_clients(key_size)
-    CreateCerts.etcd_certificates(hash[:etcd_initial_cluster], key_size)
-    CreateCerts.kube_ca(key_size)
-    CreateCerts.kube_front_proxy_ca(key_size)
-    CreateCerts.sa(key_size)
+    certs = CreateCerts.new(opts)
+    certs.etcd_ca
+    certs.etcd_clients
+    certs.etcd_certificates
+    certs.kube_ca
+    certs.kube_front_proxy_ca
+    certs.sa
     CleanUp.remove_files
-    CleanUp.clean_yaml(hash[:os])
+    CleanUp.clean_yaml(opts[:os])
   end
 end
-
-generate = Kube_tool.new
-
-generate.build_hiera(options)
+Kube_tool.build_hiera(Kube_tool.parse_args)

--- a/tooling/kube_tool/clean_up.rb
+++ b/tooling/kube_tool/clean_up.rb
@@ -1,7 +1,15 @@
 require 'fileutils'
 
 class CleanUp
-  def CleanUp.remove_files
+  def self.all(files)
+    files.each do |x|
+      if File.exist?(x)
+        FileUtils.rm_f(x)
+      end
+    end
+  end
+
+  def self.remove_files
     puts "Cleaning up files"
     FileUtils.rm Dir.glob('*.csr')
     FileUtils.rm Dir.glob('*.json')
@@ -10,7 +18,7 @@ class CleanUp
     FileUtils.rm('discovery_token_hash')
   end
 
-  def CleanUp.clean_yaml(os)
+  def self.clean_yaml(os)
     os = os.capitalize
     puts "Cleaning up yaml"
     File.write("kubernetes.yaml",File.open("kubernetes.yaml",&:read).gsub(/^---$/,""))

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -3,49 +3,44 @@ require 'securerandom'
 
 class OtherParams
 
-
-
-  def OtherParams.create(os, version, container_runtime, cni_provider, cni_provider_version, etcd_initial_cluster, etcd_ip, api_address, install_dashboard)
-    if install_dashboard.match('true')
-       install = true
-    else
-       install = false
-    end
-
+  def OtherParams.create(opts)
+    version = opts[:version]
+    container_runtime = opts[:container_runtime]
     kubernetes_minor_release = version.match(/(\d+\.)(\d+)/)[0]
 
-    if os.downcase.match('debian')
-      kubernetes_package_version = "#{version}-00"
-    elsif os.downcase.match('redhat')
-      kubernetes_package_version = version
+    kubernetes_package_version = case opts[:os].downcase
+    when 'debian'
+      "#{version}-00"
+    when 'redhat'
+      version
+    else
+      version
     end
 
-    if cni_provider.match('weave')
-       cni_network_provider = "https://cloud.weave.works/k8s/net?k8s-version=#{version}"
-       cni_pod_cidr = '10.32.0.0/12'
-    elsif
-       cni_provider.match('flannel')
-       cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'
-       cni_pod_cidr = '10.244.0.0/16'
-    elsif cni_provider.match('calico')
-       cni_network_provider = "https://docs.projectcalico.org/archive/#{cni_provider_version}/manifests/calico.yaml"
-       cni_pod_cidr = '192.168.0.0/16'
-    elsif cni_provider.match('calico-tigera')
-       cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"
-       cni_network_provider = "https://docs.projectcalico.org/manifests/custom-resources.yaml"
-       cni_pod_cidr = '192.168.0.0/16'
-    elsif cni_provider.match('cilium')
+    case opts[:cni_provider]
+    when 'weave'
+      cni_network_provider = "https://cloud.weave.works/k8s/net?k8s-version=#{version}"
+      cni_pod_cidr = '10.32.0.0/12'
+    when 'flannel'
+      cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'
+      cni_pod_cidr = '10.244.0.0/16'
+    when 'calico'
+      cni_network_provider = "https://docs.projectcalico.org/archive/#{opts[:cni_provider_version]}/manifests/calico.yaml"
+      cni_pod_cidr = '192.168.0.0/16'
+    when 'calico-tigera'
+      cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"
+      cni_network_provider = "https://docs.projectcalico.org/manifests/custom-resources.yaml"
+      cni_pod_cidr = '192.168.0.0/16'
+    when 'cilium'
       cni_pod_cidr = '10.244.0.0/16'
       if container_runtime.match('docker')
-        cni_network_provider = "https://raw.githubusercontent.com/cilium/cilium/#{cni_provider_version}/examples/kubernetes/#{kubernetes_minor_release}/cilium.yaml"
+        cni_network_provider = "https://raw.githubusercontent.com/cilium/cilium/#{opts[:cni_provider_version]}/examples/kubernetes/#{kubernetes_minor_release}/cilium.yaml"
       elsif container_runtime.match('crio')
-        cni_network_provider = "https://raw.githubusercontent.com/cilium/cilium/#{cni_provider_version}/examples/kubernetes/#{kubernetes_minor_release}/cilium-crio.yaml"
+        cni_network_provider = "https://raw.githubusercontent.com/cilium/cilium/#{opts[:cni_provider_version]}/examples/kubernetes/#{kubernetes_minor_release}/cilium-crio.yaml"
       end
     end
 
-
-
-    x = etcd_initial_cluster.split(",")
+    x = opts[:etcd_initial_cluster].split(",")
     cluster = String.new
     peers = String.new
     bootstrap_controller = x[0]
@@ -66,8 +61,6 @@ class OtherParams
     api_server_count = x.length
 
 
-
-
     data = Hash.new
     data['kubernetes::kubernetes_version'] = version
     data['kubernetes::kubernetes_package_version'] = kubernetes_package_version
@@ -77,13 +70,13 @@ class OtherParams
     end
     data['kubernetes::cni_network_provider'] = cni_network_provider
     data['kubernetes::cni_pod_cidr'] = cni_pod_cidr
-    data['kubernetes::cni_provider'] = cni_provider
+    data['kubernetes::cni_provider'] = opts[:cni_provider]
     data['kubernetes::etcd_initial_cluster'] = etcd_initial_cluster
     data['kubernetes::etcd_peers'] = etcd_peers
-    data['kubernetes::etcd_ip'] = etcd_ip
-    data['kubernetes::kube_api_advertise_address'] = api_address
+    data['kubernetes::etcd_ip'] = opts[:etcd_ip]
+    data['kubernetes::kube_api_advertise_address'] = opts[:api_address]
     data['kubernetes::api_server_count'] = api_server_count
-    data['kubernetes::install_dashboard'] = install
+    data['kubernetes::install_dashboard'] = opts[:install_dashboard]
     data['kubernetes::controller_address'] = controller_address
     data['kubernetes::token'] = SecureRandom.hex(3) + "." + SecureRandom.hex(8)
     File.open("kubernetes.yaml", "w+") { |file| file.write(data.to_yaml) }

--- a/tooling/start-kubetool.sh
+++ b/tooling/start-kubetool.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-KEY_SIZE="${KEY_SIZE:-2048}"
-
-/etc/k8s/kube_tool.rb -o ${OS} -v ${VERSION} -r ${CONTAINER_RUNTIME} -c ${CNI_PROVIDER}\
- -p ${CNI_PROVIDER_VERSION} -i ${ETCD_INITIAL_CLUSTER} -t ${ETCD_IP} -a ${KUBE_API_ADVERTISE_ADDRESS}\
- -d ${INSTALL_DASHBOARD} -b ${KEY_SIZE}


### PR DESCRIPTION
Use less code to do the same thing. Arguments are defined in one place and can be read from `ENV` without using bash script to translate ARGS.

- Upgraded Ruby base image
- Fixed insecure CA algorithm
- Short options remained the same:
```
usage: /etc/k8s/kube_tool.rb [options]
    -o, --os                    The OS that Kubernetes will run on
    -v, --version               The Kubernetes version to install
    -r, --container_runtime     The container runtime to use. This can only be "docker" or "cri_containerd"
    -c, --cni_provider          The networking provider to use, flannel, weave, calico, calico-tigera or cilium are supported
    -p, --cni_provider_version  The networking provider version to use, calico and cilium will use this to reference the correct deployment download link
    -t, --etcd_ip               The IP address etcd will listen on
    -i, --etcd_initial_cluster  The list of servers in the etcd cluster
    -a, --api_address           The IP address (or fact) that kube api will listen on
    -b, --key_size              Specifies the number of bits in the key to create
    -d, --install_dashboard     Whether install the kube dashboard
    -h, --help                  print the help
```

After upgrading the golang base image #589, the `cloudflare/cfssl`  doesn't have fixed version and  might eventually break with any breaking change. Currently generating CA certificates is broken.