### PR TITLE
Support overriding containerd socket path (#596)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,12 @@ The configuration for the image pause container.
 
 Default `k8s.gcr.io/pause:3.2`.
 
+### `containerd_socket`
+
+The path to containerd GRPC socket.
+
+Default: `/run/containerd/containerd.sock`
+
 #### `controller_address`
 
 The IP address and port for the controller the worker node joins. For example `172.17.10.101:6443`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,10 @@
 #   This value overrides containerd_config_template
 #   Default to undef
 #
+# [*containerd_socket*]
+#   The path to containerd GRPC socket
+#   Defaults to /run/containerd/containerd.sock
+#
 # [*containerd_plugins_registry*]
 #  The configuration for the image registries used by containerd when containerd_install_method is package.
 #  See https://github.com/containerd/containerd/blob/master/docs/cri/registry.md
@@ -658,6 +662,7 @@ class kubernetes (
   String $containerd_source                               =
     "https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive}",
   String $containerd_config_template                      = 'kubernetes/containerd/config.toml.erb',
+  Variant[Stdlib::Unixpath, String] $containerd_socket    = '/run/containerd/containerd.sock',
   Optional[String] $containerd_config_source              = undef,
   Hash $containerd_plugins_registry                       = {
     'docker.io' => {

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -46,6 +46,7 @@ class kubernetes::packages (
   Optional[String] $https_proxy                         = $kubernetes::https_proxy,
   Optional[String] $no_proxy                            = $kubernetes::no_proxy,
   Boolean $container_runtime_use_proxy                  = $kubernetes::container_runtime_use_proxy,
+  Variant[Stdlib::Unixpath, String] $containerd_socket  = $kubernetes::containerd_socket,
 ) {
   # Download directory for archives
   file { $tmp_directory:

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -369,6 +369,9 @@ describe 'kubernetes::packages', :type => :class do
         /\s*ca_file = "ca2.pem"\s*/
     )}
     it { should_not contain_file('/etc/apt/preferences.d/containerd')}
+    it { is_expected.to contain_file('/etc/containerd/config.toml').with_content(
+        %r{\saddress = "/run/containerd/containerd.sock"}
+    )}
   end
 
   context 'with osfamily => RedHat and container_runtime => cri_containerd and containerd_install_method => package and containerd_default_runtime_name => nvidia and manage_etcd => true' do
@@ -1059,6 +1062,7 @@ describe 'kubernetes::packages', :type => :class do
         'etcd_archive_checksum' => '9ba70e27c17a1faf6d3de89040432189d8071fa27ca156d09d3503989ecd9ccd',
         'runc_source_checksum' => '6e8b24be90fffce6b025d254846da9d2ca6d65125f9139b6354bab0272253d01',
         'tmp_directory' => '/var/tmp/puppetlabs-kubernetes',
+        'containerd_socket' => 'unix:///run/containerd/containerd.sock'
         }
     end
     it { is_expected.to contain_file_line('remove swap in /etc/fstab')}
@@ -1079,5 +1083,8 @@ describe 'kubernetes::packages', :type => :class do
     it { is_expected.not_to contain_file('/etc/apt/preferences.d/docker')}
     it { is_expected.to contain_file('/etc/apt/preferences.d/kubernetes')}
     it { is_expected.not_to contain_file('/etc/systemd/system/docker.service.d')}
+    it { is_expected.to contain_file('/etc/containerd/config.toml').with_content(
+        %r{\saddress = "unix:///run/containerd/containerd.sock"}
+    )}
   end
 end

--- a/templates/containerd/config.toml.erb
+++ b/templates/containerd/config.toml.erb
@@ -7,7 +7,7 @@ required_plugins = []
 oom_score = 0
 
 [grpc]
-  address = "unix:///run/containerd/containerd.sock"
+  address = "<%= @containerd_socket -%>"
   tcp_address = ""
   tcp_tls_cert = ""
   tcp_tls_key = ""


### PR DESCRIPTION
This commits reverts changes done in cfbd9de13d52cf260b1776f005ef91125d8263d0  (#576) while allowing overriding socket path via `kubernetes::containerd_socket` parameter.

The address `unix:///run/containerd/containerd.sock` doesn't seem to be supported by all `containerd` versions.
cc @chelnak 
Fixes #596.