### PR TITLE
Fix executing CNI addons commands (fixes #594)

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -24,11 +24,11 @@ class kubernetes::kube_addons (
     try_sleep   => 30,
   }
 
-  $exec_onlyif = ['kubectl get nodes']
+  $exec_onlyif = 'kubectl get nodes'
 
   if $cni_rbac_binding {
     $binding_command = ['kubectl', 'apply', '-f', $cni_rbac_binding]
-    $binding_unless = ['kubectl get clusterrole | grep calico']
+    $binding_unless = 'kubectl get clusterrole | grep calico'
 
     exec { 'Install calico rbac bindings':
       environment => $env,
@@ -42,7 +42,7 @@ class kubernetes::kube_addons (
     if $cni_provider == 'calico-tigera' {
       if $cni_network_preinstall {
         $preinstall_command = ['kubectl', 'apply', '-f', $cni_network_preinstall]
-        $preinstall_unless = ['kubectl -n tigera-operator get deployments | egrep "^tigera-operator"']
+        $preinstall_unless = 'kubectl -n tigera-operator get deployments | egrep "^tigera-operator"'
 
         exec { 'Install cni network (preinstall)':
           command     => $preinstall_command,
@@ -54,8 +54,8 @@ class kubernetes::kube_addons (
       }
       # Removing Calico_installation_path variable as it doesnt seem to apport any extra value here.
       $calico_installation_path = '/etc/kubernetes/calico-installation.yaml'
-      $path_command = ['kubectl', 'apply', '-f', '/etc/kubernetes/calico-installation.yaml']
-      $path_unless = ['kubectl -n calico-system get daemonset | egrep "^calico-node"']
+      $path_command = 'kubectl apply -f /etc/kubernetes/calico-installation.yaml'
+      $path_unless = 'kubectl -n calico-system get daemonset | egrep "^calico-node"'
 
       file { $calico_installation_path:
         ensure  => 'present',
@@ -79,7 +79,7 @@ class kubernetes::kube_addons (
       }
     } else {
       $provider_command = ['kubectl', 'apply', '-f', $cni_network_provider]
-      $provider_unless = ['kubectl -n kube-system get daemonset | egrep "(flannel|weave|calico-node|cilium)"']
+      $provider_unless = 'kubectl -n kube-system get daemonset | egrep "(flannel|weave|calico-node|cilium)"'
 
       exec { 'Install cni network provider':
         command     => $provider_command,
@@ -96,7 +96,7 @@ class kubernetes::kube_addons (
 
   if $schedule_on_controller {
     $schedule_command = ['kubectl', 'taint', 'nodes', $node_name, 'node-role.kubernetes.io/master-']
-    $schedule_onlyif = ['kubectl describe nodes ${node_name} | tr -s " " | grep "Taints: node-role.kubernetes.io/master:NoSchedule"']
+    $schedule_onlyif = "kubectl describe nodes ${node_name} | tr -s ' ' | grep 'Taints: node-role.kubernetes.io/master:NoSchedule'"
 
     exec { 'schedule on controller':
       command => $schedule_command,

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -24,15 +24,16 @@ class kubernetes::kube_addons (
     try_sleep   => 30,
   }
 
+  $exec_onlyif = ['kubectl get nodes']
+
   if $cni_rbac_binding {
     $binding_command = ['kubectl', 'apply', '-f', $cni_rbac_binding]
-    $binding_onlyif = ['kubectl', 'get', 'nodes']
     $binding_unless = ['kubectl get clusterrole | grep calico']
 
     exec { 'Install calico rbac bindings':
       environment => $env,
       command     => $binding_command,
-      onlyif      => $binding_onlyif,
+      onlyif      => $exec_onlyif,
       unless      => $binding_unless,
     }
   }
@@ -41,12 +42,11 @@ class kubernetes::kube_addons (
     if $cni_provider == 'calico-tigera' {
       if $cni_network_preinstall {
         $preinstall_command = ['kubectl', 'apply', '-f', $cni_network_preinstall]
-        $preinstall_onlyif = ['kubectl', 'get', 'nodes']
-        $preinstall_unless = "kubectl -n tigera-operator get deployments | egrep '^tigera-operator'"
+        $preinstall_unless = ['kubectl -n tigera-operator get deployments | egrep "^tigera-operator"']
 
         exec { 'Install cni network (preinstall)':
           command     => $preinstall_command,
-          onlyif      => $preinstall_onlyif,
+          onlyif      => $exec_onlyif,
           unless      => $preinstall_unless,
           environment => $env,
           before      => Exec['Install cni network provider'],
@@ -55,8 +55,7 @@ class kubernetes::kube_addons (
       # Removing Calico_installation_path variable as it doesnt seem to apport any extra value here.
       $calico_installation_path = '/etc/kubernetes/calico-installation.yaml'
       $path_command = ['kubectl', 'apply', '-f', '/etc/kubernetes/calico-installation.yaml']
-      $path_onlyif = ['kubectl', 'get', 'nodes']
-      $path_unless = "kubectl -n calico-system get daemonset | egrep '^calico-node'"
+      $path_unless = ['kubectl -n calico-system get daemonset | egrep "^calico-node"']
 
       file { $calico_installation_path:
         ensure  => 'present',
@@ -74,18 +73,17 @@ class kubernetes::kube_addons (
         replace  => true,
       } -> exec { 'Install cni network provider':
         command     => $path_command,
-        onlyif      => $path_onlyif,
+        onlyif      => $exec_onlyif,
         unless      => $path_unless,
         environment => $env,
       }
     } else {
       $provider_command = ['kubectl', 'apply', '-f', $cni_network_provider]
-      $provider_onlyif = ['kubectl', 'get', 'nodes']
-      $provider_unless = "kubectl -n kube-system get daemonset | egrep '(flannel|weave|calico-node|cilium)'"
+      $provider_unless = ['kubectl -n kube-system get daemonset | egrep "(flannel|weave|calico-node|cilium)"']
 
       exec { 'Install cni network provider':
         command     => $provider_command,
-        onlyif      => $provider_onlyif,
+        onlyif      => $exec_onlyif,
         unless      => $provider_unless,
         environment => $env,
       }
@@ -98,7 +96,7 @@ class kubernetes::kube_addons (
 
   if $schedule_on_controller {
     $schedule_command = ['kubectl', 'taint', 'nodes', $node_name, 'node-role.kubernetes.io/master-']
-    $schedule_onlyif = "kubectl describe nodes ${node_name} | tr -s ' ' | grep 'Taints: node-role.kubernetes.io/master:NoSchedule'"
+    $schedule_onlyif = ['kubectl describe nodes ${node_name} | tr -s " " | grep "Taints: node-role.kubernetes.io/master:NoSchedule"']
 
     exec { 'schedule on controller':
       command => $schedule_command,
@@ -108,13 +106,14 @@ class kubernetes::kube_addons (
 
   if $install_dashboard {
     $dashboard_command = ['kubectl', 'apply', '-f', $dashboard_url]
-    $dashboard_onlyif = ['kubectl', 'get', 'nodes']
-    $dashboard_unless = [['kubectl get pods --field-selector="status.phase=Running" -n kubernetes-dashboard | grep kubernetes-dashboard-'],
-    ['kubectl get pods --field-selector="status.phase=Running" -n kube-system | grep kubernetes-dashboard-']]
+    $dashboard_unless = [
+      'kubectl get pods --field-selector="status.phase=Running" -n kubernetes-dashboard | grep kubernetes-dashboard-',
+      'kubectl get pods --field-selector="status.phase=Running" -n kube-system | grep kubernetes-dashboard-'
+    ]
 
     exec { 'Install Kubernetes dashboard':
       command     => $dashboard_command,
-      onlyif      => $dashboard_onlyif,
+      onlyif      => $exec_onlyif,
       unless      => $dashboard_unless,
       environment => $env,
     }

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -4,98 +4,114 @@ describe 'kubernetes::kube_addons', :type => :class do
   let(:facts) do
     {
       :os               => {
-        :family => "Debian",
+        :family => 'Debian',
         :name    => 'Ubuntu',
         :release => {
-          :full => '16.04',
+          :full => '22.04',
         },
         :distro => {
-          :codename => "xenial",
+          :codename => 'jammy',
         },
       },
     }
   end
   context 'with controller => true and schedule_on_controller => true' do
     let(:params) do {
-      'controller' => true,
-      'cni_rbac_binding' => 'foo',
-      'cni_network_provider' => 'https://foo.test',
-      'install_dashboard' => false,
-      'kubernetes_version' => '1.10.2',
-      'schedule_on_controller' => true,
-      'node_name' => 'foo',
+      controller: true,
+      cni_rbac_binding: 'foo',
+      cni_network_provider: 'https://foo.test',
+      install_dashboard: false,
+      kubernetes_version: '1.25.4',
+      schedule_on_controller: true,
+      node_name: 'foo',
       }
     end
 
-    it { should contain_exec('Install calico rbac bindings')}
-    it { should contain_exec('Install cni network provider')}
-    it { should contain_exec('schedule on controller')}
+    it { is_expected.to contain_exec('Install calico rbac bindings').with({
+      'command': ['kubectl', 'apply', '-f', 'foo'],
+      'onlyif': ['kubectl get nodes'],
+      })
+    }
+    it { is_expected.to contain_exec('Install cni network provider').with({
+      'command': ['kubectl', 'apply', '-f', 'https://foo.test'],
+      'onlyif': ['kubectl get nodes'],
+      })
+    }
+    it { is_expected.to contain_exec('schedule on controller')}
 
-    it { should_not contain_exec('Install cni network (preinstall)')}
-    it { should_not contain_file('/etc/kubernetes/calico-installation.yaml')}
-    it { should_not contain_file_line('Configure calico ipPools.cidr')}
+    it { is_expected.not_to contain_exec('Install cni network (preinstall)')}
+    it { is_expected.not_to contain_file('/etc/kubernetes/calico-installation.yaml')}
+    it { is_expected.not_to contain_file_line('Configure calico ipPools.cidr')}
   end
 
-  context 'with cni_provider => calico' do
-    let(:params) do {
-      'controller' => true,
-      'cni_network_provider' => 'https://foo.test',
-      'cni_provider' => 'calico',
-      'install_dashboard' => false,
-      'kubernetes_version' => '1.10.2',
-      'node_name' => 'foo',
-      }
+
+  context 'CNI network provider' do
+    ['flannel', 'weave', 'calico', 'cilium', 'calico-tigera'].each do |provider|
+
+      context "with #{provider}" do
+        let(:params) do {
+          controller: true,
+          cni_network_provider: "https://#{provider}.test",
+          cni_network_preinstall: 'https://foo.test/tigera-operator',
+          cni_provider: provider,
+          install_dashboard: false,
+          kubernetes_version: '1.25.4',
+          node_name: 'foo',
+          }
+        end
+
+        case provider
+        when 'calico-tigera'
+          it { is_expected.to contain_exec('Install cni network (preinstall)').with({
+            'command': ['kubectl', 'apply', '-f', 'https://foo.test/tigera-operator'],
+            'onlyif': ['kubectl get nodes'],
+            })
+          }
+          it { is_expected.to contain_file('/etc/kubernetes/calico-installation.yaml')}
+          it { is_expected.to contain_file_line('Configure calico ipPools.cidr')}
+          it { is_expected.to contain_exec('Install cni network provider')}
+        else
+          it {
+            is_expected.to contain_exec('Install cni network provider').with({
+              'onlyif': ['kubectl get nodes'],
+              'command': ['kubectl', 'apply', '-f', "https://#{provider}.test"],
+              'unless': ['kubectl -n kube-system get daemonset | egrep "(flannel|weave|calico-node|cilium)"'],
+            })
+          }
+
+          it { is_expected.not_to contain_exec('Install cni network (preinstall)').with({
+              'onlyif': ['kubectl get nodes'],
+            })
+          }
+        end
+      end
     end
-
-    it { should contain_exec('Install cni network provider')}
-
-    it { should_not contain_exec('Install cni network (preinstall)')}
-    it { should_not contain_file('/etc/kubernetes/calico-installation.yaml')}
-    it { should_not contain_file_line('Configure calico ipPools.cidr')}
-  end
-
-  context 'with cni_provider => calico-tigera' do
-    let(:params) do {
-      'controller' => true,
-      'cni_network_preinstall' => 'https://foo.test/tigera-operator',
-      'cni_network_provider' => 'https://foo.test',
-      'cni_provider' => 'calico-tigera',
-      'install_dashboard' => false,
-      'kubernetes_version' => '1.10.2',
-      'node_name' => 'foo',
-      }
-    end
-
-    it { should contain_exec('Install cni network (preinstall)')}
-    it { should contain_file('/etc/kubernetes/calico-installation.yaml')}
-    it { should contain_file_line('Configure calico ipPools.cidr')}
-    it { should contain_exec('Install cni network provider')}
   end
 
   context 'with install_dashboard => false' do
     let(:params) do {
-      'controller' => true,
-      'cni_rbac_binding' => nil,
-      'cni_network_provider' => 'https://foo.test',
-      'install_dashboard' => false,
-      'kubernetes_version' => '1.10.2',
-      'schedule_on_controller' => false,
-      'node_name' => 'foo',
+      controller: true,
+      cni_rbac_binding: nil,
+      cni_network_provider: 'https://foo.test',
+      install_dashboard: false,
+      kubernetes_version: '1.25.4',
+      schedule_on_controller: false,
+      node_name: 'foo',
       }
     end
-    it { is_expected.to_not contain_exec('Install Kubernetes dashboard')}
+    it { is_expected.not_to contain_exec('Install Kubernetes dashboard')}
   end
 
   context 'with install_dashboard => true' do
     let(:params) do {
-      'controller' => true,
-      'cni_rbac_binding' => nil,
-      'cni_network_provider' => 'https://foo.test',
-      'install_dashboard' => true,
-      'kubernetes_version' => '1.10.2',
-      'dashboard_version' => '1.10.1',
-      'schedule_on_controller' => false,
-      'node_name' => 'foo',
+      controller: true,
+      cni_rbac_binding: nil,
+      cni_network_provider: 'https://foo.test',
+      install_dashboard: true,
+      kubernetes_version: '1.25.4',
+      dashboard_version: '1.10.1',
+      schedule_on_controller: false,
+      node_name: 'foo',
       }
     end
     it { is_expected.to contain_exec('Install Kubernetes dashboard').with_command(%r{dashboard/v1.10.1/src}) }


### PR DESCRIPTION
This PR attempts to fix some changes introduced in #592 and #575.

- Wrap commands in single array
- Don't use double quotes for strings where string interpolation isn't needed
- Avoid unnecessary code duplication

The exec containing `command` in form 

```
['kubectl', 'get', 'nodes']
```
will print help message to stdout instead of executing `kubectl get nodes`.

