### PR TITLE
Stronger type checking for $node_name

### DIFF
--- a/manifests/cluster_roles.pp
+++ b/manifests/cluster_roles.pp
@@ -3,7 +3,7 @@
 class kubernetes::cluster_roles (
   Optional[Boolean] $controller = $kubernetes::controller,
   Optional[Boolean] $worker = $kubernetes::worker,
-  String $node_name = $kubernetes::node_name,
+  Stdlib::Fqdn $node_name = $kubernetes::node_name,
   String $container_runtime = $kubernetes::container_runtime,
   Optional[String] $join_discovery_file = $kubernetes::join_discovery_file,
   Optional[Array] $ignore_preflight_errors = $kubernetes::ignore_preflight_errors,

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -49,7 +49,7 @@ class kubernetes::config::kubeadm (
   Optional[Array] $scheduler_extra_arguments = $kubernetes::scheduler_extra_arguments,
   Optional[Array] $kubelet_extra_arguments = $kubernetes::kubelet_extra_arguments,
   String $service_cidr = $kubernetes::service_cidr,
-  String $node_name = $kubernetes::node_name,
+  Stdlib::Fqdn $node_name = $kubernetes::node_name,
   Optional[String] $cloud_provider = $kubernetes::cloud_provider,
   Optional[String] $cloud_config = $kubernetes::cloud_config,
   Optional[Hash] $apiserver_extra_volumes = $kubernetes::apiserver_extra_volumes,

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -1,6 +1,6 @@
 # Class kubernetes config_worker, populates worker config files with joinconfig
 class kubernetes::config::worker (
-  String $node_name                        = $kubernetes::node_name,
+  Stdlib::Fqdn $node_name                  = $kubernetes::node_name,
   String $config_file                      = $kubernetes::config_file,
   String $kubernetes_version               = $kubernetes::kubernetes_version,
   String $kubernetes_cluster_name          = $kubernetes::kubernetes_cluster_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -643,7 +643,7 @@ class kubernetes (
   Array $controllermanager_extra_arguments                = [],
   Array $scheduler_extra_arguments                        = [],
   String $service_cidr                                    = '10.96.0.0/12',
-  Optional[String] $node_label                            = undef,
+  Optional[Stdlib::Fqdn] $node_label                      = undef,
   Optional[String] $controller_address                    = undef,
   Optional[String] $cloud_provider                        = undef,
   Optional[String] $cloud_config                          = undef,

--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -12,7 +12,7 @@ class kubernetes::kube_addons (
   String $kubernetes_version                = $kubernetes::kubernetes_version,
   Boolean $controller                       = $kubernetes::controller,
   Optional[Boolean] $schedule_on_controller = $kubernetes::schedule_on_controller,
-  String $node_name                         = $kubernetes::node_name,
+  Stdlib::Fqdn $node_name                   = $kubernetes::node_name,
   Array $path                               = $kubernetes::default_path,
   Optional[Array] $env                      = $kubernetes::environment,
 ) {
@@ -88,10 +88,6 @@ class kubernetes::kube_addons (
         environment => $env,
       }
     }
-  }
-
-  if $node_name !~ /^[a-zA-Z0-9]([a-zA-Z0-9\-\.]{0,251}[a-zA-Z0-9])?$/ {
-    fail("Invalid node name: ${node_name}")
   }
 
   if $schedule_on_controller {

--- a/manifests/kubeadm_init.pp
+++ b/manifests/kubeadm_init.pp
@@ -1,6 +1,6 @@
 # == kubernetes::kubeadm_init
 define kubernetes::kubeadm_init (
-  String $node_name                             = $kubernetes::node_name,
+  Stdlib::Fqdn $node_name                       = $kubernetes::node_name,
   Optional[String] $config                      = $kubernetes::config_file,
   Boolean $dry_run                              = false,
   Array $path                                   = $kubernetes::default_path,

--- a/manifests/kubeadm_join.pp
+++ b/manifests/kubeadm_join.pp
@@ -1,6 +1,6 @@
 # == kubernetes::kubeadm_join
 define kubernetes::kubeadm_join (
-  String $node_name                        = $kubernetes::node_name,
+  Stdlib::Fqdn $node_name                  = $kubernetes::node_name,
   String $kubernetes_version               = $kubernetes::kubernetes_version,
   String $config                           = $kubernetes::config_file,
   String $controller_address               = $kubernetes::controller_address,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.20.0 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-apt",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -89,6 +89,15 @@ describe 'kubernetes' do
 
         it { is_expected.to_not contain_notify('aws_name_override') }
       end
+
+      context 'with invalid node_label should not allow code injection' do
+        let(:params) do {
+          worker: true,
+          node_label: 'hostname;rm -rf /',
+        } end
+
+        it { is_expected.to raise_error(/Evaluation Error: Error while evaluating/) }
+      end
     end
   end
 end


### PR DESCRIPTION
Do not allow any arbitrary string to be passed as node_name, as the variable is frequently passed to shell scripts.

The hardening efforts #575, #592 attempts to prevent code injection also via `node_name` variable. However it broke some functionality (#594).

This PR adds type checking for `kubernetes::node_name` using [Stdlib:Fqdn](https://github.com/puppetlabs/puppetlabs-stdlib/commit/127b2f9b36b6f41a62db0d68f3908e7c227871a0) that was introduced in `puppetlabs-stdlib` in version `4.25.0`. 

Currently there's a [similar type check](https://github.com/puppetlabs/puppetlabs-kubernetes/blob/main/manifests/kube_addons.pp#L93) only in `kube_addons.pp` class
```
/^[a-zA-Z0-9]([a-zA-Z0-9\-\.]{0,251}[a-zA-Z0-9])?$/
```
the `stdlib::fqdn` pattern looks like this:
```
/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
```

@chelnak is trying to revert some of the hardening changes in #599. This PR might bring more consistent approach for all classes in this module, while avoiding possible code injection via `node_name`.
