### PR TITLE
Validate namespace parameter as DNS subdomain name

### DIFF
--- a/manifests/wait_for_default_sa.pp
+++ b/manifests/wait_for_default_sa.pp
@@ -1,18 +1,21 @@
 # == kubernetes::wait_for_default_sa
+#
+# @param namespace
+#  Namespace name must be a valid DNS name (max. 63 characters)
+#  see https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#namespaces-and-dns
+#
 define kubernetes::wait_for_default_sa (
-  String $namespace            = $title,
-  Array $path                  = $kubernetes::default_path,
-  Optional[Integer] $timeout   = undef,
-  Optional[Integer] $tries     = $kubernetes::wait_for_default_sa_tries,
-  Optional[Integer] $try_sleep = $kubernetes::wait_for_default_sa_try_sleep,
-  Optional[Array] $env         = $kubernetes::environment,
+  Kubernetes::Namespace $namespace = $title,
+  Array $path                      = $kubernetes::default_path,
+  Optional[Integer] $timeout       = undef,
+  Optional[Integer] $tries         = $kubernetes::wait_for_default_sa_tries,
+  Optional[Integer] $try_sleep     = $kubernetes::wait_for_default_sa_try_sleep,
+  Optional[Array] $env             = $kubernetes::environment,
 ) {
-  $safe_namespace = shell_escape($namespace)
-
   # This prevents a known race condition https://github.com/kubernetes/kubernetes/issues/66689
-  exec { "wait for default serviceaccount creation in ${safe_namespace}":
-    command     => "kubectl -n ${safe_namespace} get serviceaccount default -o name",
-    unless      => ["kubectl -n ${safe_namespace} get serviceaccount default -o name"],
+  exec { "wait for default serviceaccount creation in ${namespace}":
+    command     => "kubectl -n ${namespace} get serviceaccount default -o name",
+    unless      => "kubectl -n ${namespace} get serviceaccount default -o name",
     path        => $path,
     environment => $env,
     timeout     => $timeout,

--- a/types/namespace.pp
+++ b/types/namespace.pp
@@ -1,0 +1,3 @@
+# namespace should conform to RFC 1123
+# source https://stackoverflow.com/a/20945961/334831
+type Kubernetes::Namespace = Pattern['\A(?!-)[a-zA-Z0-9-]{1,63}(?<!-)\z']


### PR DESCRIPTION
[Namespace naming](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) should conform to DNS subdomain name as defined in [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) and [RFC 1123](https://tools.ietf.org/html/rfc1123):

- contain at most 63 characters
- contain only lowercase alphanumeric characters or '-'
- start with an alphanumeric character
- end with an alphanumeric character

When enforcing such policy code injection should not be possible (no need to escape namespace name).