### PR TITLE
(maint) - Bump dependencies before major release 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": "< 9.0.0"
+      "version_requirement": "< 10.0.0"
     },
     {
       "name": "puppet-archive",


### PR DESCRIPTION
bumping puppetlabs-apt dependency version requirement from <9.0.0 to <10.0.0.