### PR TITLE
(MAINT) -  update-deprecated-dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
       "version_requirement": ">= 2.2.1 < 3.0.0"
     },
     {
-      "name": "herculesteam-augeasproviders_core",
+      "name": "puppet-augeasproviders_core",
       "version_requirement": ">= 2.1.0 < 4.0.0"
     },
     {


### PR DESCRIPTION
the use of herculesteam-augeasproviders_core has been deprecated and should be replaced with puppet-augeasproviders_core.