### PR TITLE
Update GPG fingerprint for apt.kubernetes.io

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -30,7 +30,7 @@ class kubernetes::repos (
           repos    => pick($kubernetes_apt_repos,'main'),
           release  => pick($kubernetes_apt_release,'kubernetes-xenial'),
           key      => {
-            'id'     => pick($kubernetes_key_id,'7F92E05B31093BEF5A3C2D38FEEA9169307EA071'),
+            'id'     => pick($kubernetes_key_id,'A362B822F6DEDC652817EA46B53DC80D13EDEF05'),
             'source' => pick($kubernetes_key_source,'https://packages.cloud.google.com/apt/doc/apt-key.gpg'),
           },
         }


### PR DESCRIPTION
On Debian based distributions following error might appear, due to outdated GPG key:

```
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
W: Failed to fetch https://apt.kubernetes.io/dists/kubernetes-xenial/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
W: Some index files failed to download. They have been ignored, or old ones used instead.
```
As a workaround the default value can be overrided in Hiera config:
```yaml
kubernetes::kubernetes_key_id: A362B822F6DEDC652817EA46B53DC80D13EDEF05
```