### PR TITLE
(MAINT) - update pdk release image

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -34,7 +34,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:


### PR DESCRIPTION
This PR updates the pdk release image used in auto_release.yaml from puppet/iac_release:ci to puppet/pdk:2.6.1.0.