### PR TITLE
Fix flannel install condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ class {'kubernetes':
 }
 ```
 
+#### Network Plugins
+
+Kubernetes supports multiple [networking plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) that implements the [networking model](https://kubernetes.io/docs/concepts/services-networking/#the-kubernetes-network-model).
+
+This module supports following [Container Network Interface](https://github.com/containernetworking/cni) (CNI) plugins:
+
+- `flannel`
+```yaml
+kubernetes::cni_network_provider: https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+kubernetes::cni_pod_cidr: 10.244.0.0/16
+kubernetes::cni_provider: flannel
+```
+- `weave`
+- `calico-node`
+- `cilium`
+```yaml
+kubernetes::cni_network_provider: https://raw.githubusercontent.com/cilium/cilium/1.4.3/examples/kubernetes/1.26/cilium.yaml
+kubernetes::cni_pod_cidr: 10.244.0.0/16
+kubernetes::cni_provider: cilium
+```
+
 #### Installing Kubernetes on different OS
 
 Currently, `puppetlab-kubernetes` is compatible with Ubuntu Xenial. For different OS, below parameters can be assigned.

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -81,6 +81,16 @@ describe 'kubernetes::kube_addons', type: :class do
           it { is_expected.to contain_file('/etc/kubernetes/calico-installation.yaml') }
           it { is_expected.to contain_file_line('Configure calico ipPools.cidr') }
           it { is_expected.to contain_exec('Install cni network provider') }
+        when 'flannel'
+          it {
+            expect(subject).to contain_exec('Install cni network provider').with(
+              {
+                onlyif: ['kubectl get nodes'],
+                command: ['kubectl', 'apply', '-f', "https://#{provider}.test"],
+                unless: ['kubectl -n kube-flannel get daemonset | egrep "^kube-flannel"']
+              },
+            )
+          }
         else
           it {
             expect(subject).to contain_exec('Install cni network provider').with({

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -24,7 +24,7 @@ class OtherParams
       cni_network_provider = 'https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s-1.11.yaml'
       cni_pod_cidr = '10.32.0.0/12'
     when 'flannel'
-      cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'
+      cni_network_provider = 'https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml'
       cni_pod_cidr = '10.244.0.0/16'
     when 'calico'
       cni_network_provider = "https://docs.projectcalico.org/archive/v#{opts[:cni_provider_version]}/manifests/calico.yaml"


### PR DESCRIPTION
Flannel CNI is installed into `kube-flannel` namespace, not `kube-system`, see e.g. [kube-flannel.yml](https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml)

This PR fixes a corrective flannel installation that is repeated on each puppet run, when `flannel` CNI is used.