### PR TITLE
General fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ For example,
 
 The configuration for the image pause container.
 
-Default `k8s.gcr.io/pause:3.2`.
+Default `registry.k8s.io/pause:3.2`.
 
 ### `containerd_socket`
 
@@ -671,7 +671,7 @@ Defaults to `undef`.
 
 The container registry to pull control plane images from.
 
-Defaults to k8s.gcr.io
+Defaults to registry.k8s.io
 
 #### `install_dashboard`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -648,7 +648,7 @@ the files if they do not exist.
 
 [*containerd_sandbox_image*]
  The configuration for the image pause container
- Defaults k8s.gcr.io/pause:3.2
+ Defaults registry.k8s.io/pause:3.2
 
 [*dns_domain*]
   This is a string that sets the dns domain in kubernetes cluster
@@ -949,7 +949,7 @@ Example:
 
 [*image_repository*]
  The container registry to pull control plane images from
- Defaults to k8s.gcr.io
+ Defaults to registry.k8s.io
 
 [*kubeadm_extra_config*]
  A hash containing extra configuration data to be serialised with `to_yaml` and appended to the config.yaml file used by kubeadm.
@@ -1996,7 +1996,7 @@ Data type: `String`
 
 
 
-Default value: `'k8s.gcr.io/pause:3.2'`
+Default value: `'registry.k8s.io/pause:3.2'`
 
 ##### <a name="-kubernetes--etcd_archive"></a>`etcd_archive`
 
@@ -2274,7 +2274,7 @@ Data type: `String`
 
 
 
-Default value: `'k8s.gcr.io'`
+Default value: `'registry.k8s.io'`
 
 ##### <a name="-kubernetes--default_path"></a>`default_path`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@
 #
 # [*containerd_sandbox_image*]
 #  The configuration for the image pause container
-#  Defaults k8s.gcr.io/pause:3.2
+#  Defaults registry.k8s.io/pause:3.2
 #
 # [*dns_domain*]
 #   This is a string that sets the dns domain in kubernetes cluster
@@ -376,7 +376,7 @@
 #
 # [*image_repository*]
 #  The container registry to pull control plane images from
-#  Defaults to k8s.gcr.io
+#  Defaults to registry.k8s.io
 #
 # [*kubeadm_extra_config*]
 #  A hash containing extra configuration data to be serialised with `to_yaml` and appended to the config.yaml file used by kubeadm.
@@ -697,7 +697,7 @@ class kubernetes (
     },
   },
   Enum['runc','nvidia'] $containerd_default_runtime_name  = 'runc',
-  String $containerd_sandbox_image                        = 'k8s.gcr.io/pause:3.2',
+  String $containerd_sandbox_image                        = 'registry.k8s.io/pause:3.2',
   String $etcd_archive                                    = "etcd-v${etcd_version}-linux-amd64.tar.gz",
   Optional[String] $etcd_archive_checksum                 = undef,
   String $etcd_package_name                               = 'etcd-server',
@@ -734,7 +734,7 @@ class kubernetes (
   Boolean $manage_kernel_modules                          = true,
   Boolean $manage_sysctl_settings                         = true,
   Boolean $create_repos                                   = true,
-  String $image_repository                                = 'k8s.gcr.io',
+  String $image_repository                                = 'registry.k8s.io',
   Array[String] $default_path                             = ['/usr/bin', '/usr/sbin', '/bin', '/sbin', '/usr/local/bin'],
   String $cgroup_driver                                   = $facts['os']['family'] ? {
     'RedHat' => 'systemd',

--- a/templates/0-containerd.conf.erb
+++ b/templates/0-containerd.conf.erb
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_EXTRA_ARGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"

--- a/templates/v1beta3/config_kubeadm.yaml.erb
+++ b/templates/v1beta3/config_kubeadm.yaml.erb
@@ -150,4 +150,3 @@ mode: "<%= @proxy_mode %>"
 nodePortAddresses: null
 oomScoreAdj: -999
 portRange: ""
-udpIdleTimeout: 250ms

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -25,7 +25,7 @@ class OtherParams
       cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'
       cni_pod_cidr = '10.244.0.0/16'
     when 'calico'
-      cni_network_provider = "https://docs.projectcalico.org/archive/#{opts[:cni_provider_version]}/manifests/calico.yaml"
+      cni_network_provider = "https://docs.projectcalico.org/archive/v#{opts[:cni_provider_version]}/manifests/calico.yaml"
       cni_pod_cidr = '192.168.0.0/16'
     when 'calico-tigera'
       cni_network_preinstall = "https://docs.projectcalico.org/manifests/tigera-operator.yaml"


### PR DESCRIPTION
This was tested on Debian bookworm with kubernetes version 1.26 and 1.27, calico v3.25

UdpIdleTimeout has been deprecated:
- https://github.com/kubernetes-sigs/kubespray/pull/9925/files
- https://github.com/kubernetes/kubernetes/pull/112133/files

Kubernetes has moved the registry to:
- registry.k8s.io
Reference as seen in the red banner on their website:
- https://kubernetes.io/

Calico requires a `v` before the version number without it you get a 404 Example:
- https://docs.projectcalico.org/archive/v3.18/manifests/calico.yaml
- https://docs.projectcalico.org/archive/3.18/manifests/calico.yaml

container-runtime remote has been deprecated as the only possible value was remote
- Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
Error i received:
```
Apr 27 15:04:22 kubec01-mel kubelet[3790]: Flag --container-runtime-endpoint has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-co>
Apr 27 15:04:22 kubec01-mel kubelet[3790]: Flag --pod-infra-container-image has been deprecated, will be removed in a future release. Image garbage collector will get sandbox image information from CRI.
Apr 27 15:04:22 kubec01-mel kubelet[3790]: E0427 15:04:22.062236    3790 run.go:74] "command failed" err="failed to parse kubelet flag: unknown flag: --container-runtime"
```

discovery token from kubetool didnt work ( found that i needed to change rsa to pkey ) as we can see from 2 different clusters using the command with rsa gives the same result.
```
kubec01-rya.ops:/home/users/ryant# openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
kubec01-rya.ops:/home/users/ryant# openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl pkey -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
adcc248bb5ab39eb750a85f941ccfc6bfd1eef133a5aca57989ccda0eacedbdd
kubec01-rya.ops:/home/users/ryant#
```
```
kubec01-san:/home/users/ryant# openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
kubec01-san:/home/users/ryant# openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl pkey -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
84dcf2e02d0c93f1cfb2fc7af1f7757dcd204c26a6ca286a620a2bd8dc6796c2
kubec01-san:/home/users/ryant#
```

I found that on Debian the kubelet would constantly crash as the kubelet's default cgroupDriver on Debian is set to systemd
```
ryant@kubec01-san:~$ cat /var/lib/kubelet/config.yaml | grep -i cgroup
cgroupDriver: systemd
ryant@kubec01-san:~$
```
and this modules default sets containerd's cgroup_driver to cgroupfs if its not running on redhat ( found in init.pp )
The fix for Debian ( Should this just be the default for both Debian and Redhat now? ) as recommended by kubernetes [reference](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/)
```
class { '::kubernetes':
    cgroup_driver => 'systemd',
}
```
The above change sets the following in containerd's config which causes kubelet and containerd to work on Debian
```
ryant@kubec01-san:~$ cat /etc/containerd/config.toml | grep -i 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' -A 1
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            SystemdCgroup = true
ryant@kubec01-san:~$
```


And lastly calico required the mount to be shared:
Error reported
```
Apr 28 17:00:56 kubec01-san kubelet[11687]: E0428 17:00:56.926812   11687 remote_runtime.go:302] "CreateContainer in sandbox from runtime service failed" err="rpc error: code = Unknown desc = failed to generate container \"866d1ce88b3fc72e4a455ec485dfee0e3ef7cdeb84bc8146dfb949d7c87ce267\" spec: failed to generate spec: path \"/sys/fs/\" is mounted on \"/sys\" but it is not a shared mount" podSandboxID="85df3c3dfa95f1878a4b328f93cbeb021a1df366fdc8214440cd64d44451a364"
```
The fix ( This solution requires the puppet module [mount_core](https://forge.puppet.com/modules/puppetlabs/mount_core/reference) ):
```
  # For calico requires mount to be shared
  mount { "/" : atboot => yes, options => "rshared", name => "/", ensure => mounted, remounts => true, pass => "0" } ~>
  exec { "/usr/bin/mount --make-rshared /" : refreshonly => true }
```

Fixes https://github.com/puppetlabs/puppetlabs-kubernetes/issues/584