### PR TITLE
(CONT-914) - Address CI Failures

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,8 @@
       "version_requirement": ">= 2.0.0 < 7.0.0"
     },
     {
-      "name": "herculesteam-augeasproviders_sysctl",
-      "version_requirement": ">= 2.2.1 < 3.0.0"
+      "name": "puppet-augeasproviders_sysctl",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppet-augeasproviders_core",

--- a/spec/acceptance/integration_kubernetes_spec.rb
+++ b/spec/acceptance/integration_kubernetes_spec.rb
@@ -9,7 +9,7 @@ describe 'we are able to setup a controller and workers', :integration do
     after(:all) { reset_target_host }
     describe 'set up controller' do
       it 'sets up the controller' do
-        run_shell('puppet agent --test', expect_failures: true) do |r|
+        run_shell('puppet agent -t', expect_failures: true) do |r|
           expect(r.exit_code.to_s).to match(%r{0|2})
         end
       end
@@ -20,7 +20,7 @@ describe 'we are able to setup a controller and workers', :integration do
     after(:all) { reset_target_host }
     describe 'set up worker' do
       it 'sets up the worker' do
-        run_shell('puppet agent --test', expect_failures: true) do |r|
+        run_shell('puppet agent -t', expect_failures: true) do |r|
           expect(r.exit_code.to_s).to match(%r{0|2})
         end
       end
@@ -31,7 +31,7 @@ describe 'we are able to setup a controller and workers', :integration do
     after(:all) { reset_target_host }
     describe 'set up worker' do
       it 'sets up the worker' do
-        run_shell('puppet agent --test', expect_failures: true) do |r|
+        run_shell('puppet agent -t', expect_failures: true) do |r|
           expect(r.exit_code.to_s).to match(%r{0|2})
         end
       end

--- a/tooling/kube_tool/create_certs.rb
+++ b/tooling/kube_tool/create_certs.rb
@@ -88,7 +88,7 @@ class CreateCerts
     File.open("ca-csr.json", "w+") { |file| file.write(csr.to_json) }
     File.open("ca-conf.json", "w+") { |file| file.write(conf.to_json) }
     system('cfssl gencert -initca ca-csr.json | cfssljson -bare ca')
-    system("openssl x509 -pubkey -in ca.pem | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //' > discovery_token_hash")
+    system("openssl x509 -pubkey -in ca.pem | openssl pkey -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //' > discovery_token_hash")
     FileUtils.rm_f('ca.csr')
     data = Hash.new
     cer = File.read("ca.pem")

--- a/tooling/kube_tool/other_params.rb
+++ b/tooling/kube_tool/other_params.rb
@@ -19,7 +19,7 @@ class OtherParams
 
     case opts[:cni_provider]
     when 'weave'
-      cni_network_provider = "https://cloud.weave.works/k8s/net?k8s-version=#{version}"
+      cni_network_provider = "https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s-1.11.yaml"
       cni_pod_cidr = '10.32.0.0/12'
     when 'flannel'
       cni_network_provider = 'https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml'


### PR DESCRIPTION
Summary of changes:

1. Updated deprecated `herculesteam-augeasproviders_sysctl` to `puppet-augeasproviders_sysctl` to resolve dependency cycle on `install module` step
2. Pointed towards static cni-provider [weave-demonset-k8s-1.11.yaml](https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s-1.11.yaml), (as per suggested comment [here](https://github.com/weaveworks/weave/issues/3960#issuecomment-1266694062) from weave) after [cloud.weave.works](http://cloud.weave.works/) was taken out of service.
3. Updated legacy fact `$::ipaddress` to use the already present`fetch_ip_by_hostname` method in `spec_helper_acceptance_local.rb` as GCP VMs include both an internal/external IP address which caused issues.
4. Updated test manifest in `spec/acceptance/kubernetes_spec.rb` to reflect supported OS. Initially the manifest only matched redhat/debian, but we run our CI on Centos.
5. Updated generated discovery token from kubetool from rsa (bug due to mismatch on key type, fixes https://github.com/puppetlabs/puppetlabs-kubernetes/issues/614) to pkey.