### PR TITLE
Make cgroup_driver default to systemd

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1073,7 +1073,7 @@ Defaults to ""
 
 [*cgroup_driver*]
  The cgroup driver to be used.
- Defaults to 'systemd' on EL and 'cgroupfs' otherwise
+ Defaults to 'systemd'
 
 [*environment*]
 The environment passed to kubectl commands.
@@ -2290,13 +2290,8 @@ Data type: `String`
 
 
 
-Default value:
+Default value: `'systemd'`
 
-```puppet
-$facts['os']['family'] ? {
-    'RedHat' => 'systemd',
-    default  => 'cgroupfs'
-```
 
 ##### <a name="-kubernetes--environment"></a>`environment`
 

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -191,7 +191,7 @@
 #   Defaults to k8s.gcr.io
 # @param cgroup_driver
 #   The cgroup driver to be used.
-#   Defaults to 'systemd' on EL and 'cgroupfs' otherwise
+#   Defaults to 'systemd'
 # @param proxy_mode
 #   The mode for kubeproxy to run. It should be one of: "" (default), "userspace", "kernelspace", "iptables", or "ipvs".
 #   Defaults to ""

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -61,7 +61,7 @@
 #   Defaults to false
 # @param cgroup_driver
 #   The cgroup driver to be used.
-#   Defaults to 'systemd' on EL and 'cgroupfs' otherwise
+#   Defaults to 'systemd'
 # @param skip_phases_join
 #   Allow kubeadm join to skip some phases
 #   Only works with Kubernetes 1.22+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -500,7 +500,7 @@
 #
 # [*cgroup_driver*]
 #  The cgroup driver to be used.
-#  Defaults to 'systemd' on EL and 'cgroupfs' otherwise
+#  Defaults to 'systemd'
 #
 # [*environment*]
 #  The environment passed to kubectl commands.
@@ -736,10 +736,7 @@ class kubernetes (
   Boolean $create_repos                                   = true,
   String $image_repository                                = 'registry.k8s.io',
   Array[String] $default_path                             = ['/usr/bin', '/usr/sbin', '/bin', '/sbin', '/usr/local/bin'],
-  String $cgroup_driver                                   = $facts['os']['family'] ? {
-    'RedHat' => 'systemd',
-    default  => 'cgroupfs',
-  },
+  String $cgroup_driver                                   = 'systemd',
   Array[String] $environment                              = $controller ? {
     true    => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
     default => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/kubelet.conf'],

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -23,7 +23,7 @@
 # @param docker_storage_driver
 #   Storage Driver to be added to `/etc/docker/daemon.json`. Defaults to overlay2
 # @param docker_cgroup_driver
-#   The cgroup driver to be used. Defaults to 'systemd' on EL and 'cgroupfs' otherwise
+#   The cgroup driver to be used. Defaults to 'systemd'
 # @param docker_storage_opts
 #   Storage options to be added to `/etc/docker/daemon.json`. Defaults to undef
 # @param docker_extra_daemon_config

--- a/spec/acceptance/kubernetes_spec.rb
+++ b/spec/acceptance/kubernetes_spec.rb
@@ -25,7 +25,7 @@ describe 'the Kubernetes module' do
               schedule_on_controller => true,
               environment  => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
               ignore_preflight_errors => ['NumCPU','ExternalEtcdVersion'],
-              cgroup_driver => 'cgroupfs',
+              cgroup_driver => 'systemd',
             }
           }
           /^(Debian|Ubuntu)$/: {

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -81,21 +81,21 @@ def configure_puppet_server(controller, worker1, worker2)
       schedule_on_controller => true,
       environment  => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
       ignore_preflight_errors => ['NumCPU','ExternalEtcdVersion'],
-      cgroup_driver => 'cgroupfs',
+      cgroup_driver => 'systemd',
     }
   }
   node /#{worker1}/ {
     class {'kubernetes':
       worker => true,
       manage_docker => false,
-      cgroup_driver => 'cgroupfs',
+      cgroup_driver => 'systemd',
     }
   }
   node /#{worker2}/  {
     class {'kubernetes':
       worker => true,
       manage_docker => false,
-      cgroup_driver => 'cgroupfs',
+      cgroup_driver => 'systemd',
     }
   }
   EOS


### PR DESCRIPTION
As per prior discussion within this PR I've made systemd the default cgroup_driver for the next major release or when ready.
https://github.com/puppetlabs/puppetlabs-kubernetes/pull/625
https://github.com/puppetlabs/puppetlabs-kubernetes/pull/625#issuecomment-1551496610

TLDR;
The default cgroup_driver for kubelet is systemd, however the default within this module for containerd is set to cgroupfs which causes a conflict between containerd & kubelet leading to kubelet crashlooping. This PR is to set the default cgroup_driver for containerd to systemd as recommended by the kubernetes team [Kubernetes Docs for this](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/)
Tested on Debian bullseye & bookworm.

There are still a few files which have this set to cgroupfs as seen here:
```
ryant@Ryans-MacBook-Air:~/puppetlabs-kubernetes on  systemd_cgroup_driver_default took 2s ❯ grep -r cgroupfs
spec/classes/packages_spec.rb:      'docker_cgroup_driver' => 'cgroupfs',
spec/classes/packages_spec.rb:    it { is_expected.to contain_file('/etc/docker/daemon.json').with_content(%r{\s*"native.cgroupdriver=cgroupfs"\s*}) }
spec/spec_helper_acceptance_local.rb:      cgroup_driver => 'cgroupfs',
spec/spec_helper_acceptance_local.rb:      cgroup_driver => 'cgroupfs',
spec/spec_helper_acceptance_local.rb:      cgroup_driver => 'cgroupfs',
spec/acceptance/kubernetes_spec.rb:              cgroup_driver => 'cgroupfs',
ryant@Ryans-MacBook-Air:~/puppetlabs-kubernetes on  systemd_cgroup_driver_default ❯
```