### PR TITLE
(MAINT) - Update default fact with hostname

### DIFF
--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,8 +3,8 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 networking:
-    ip: "172.16.254.254"
-    ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
-    mac: "AA:AA:AA:AA:AA:AA"
-    hostname: 'kubernetes.localhost'
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
+  hostname: 'kubernetes.localhost'
 is_pe: false

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,4 +6,5 @@ networking:
     ip: "172.16.254.254"
     ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
     mac: "AA:AA:AA:AA:AA:AA"
+    hostname: 'kubernetes.localhost'
 is_pe: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
## Summary
Fixing the spec failure caused while removing legacy spec with updated one.

## Additional Context
- Replacing [legacy facts](https://github.com/puppetlabs/puppetlabs-kubernetes/pull/645) with updated caused spec failure.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)