### PR TITLE
Update kube_addons.pp

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -79,7 +79,7 @@ class kubernetes::kube_addons (
       'calico-tigera': {
         if $cni_network_preinstall {
           exec { 'Install cni network (preinstall)':
-            command     => ['kubectl', 'apply', '-f', $cni_network_preinstall],
+            command     => ['kubectl', 'create', '-f', $cni_network_preinstall],
             onlyif      => $exec_onlyif,
             unless      => 'kubectl -n tigera-operator get deployments | egrep "^tigera-operator"',
             environment => $env,


### PR DESCRIPTION
## Summary
According to installation instructions here: https://docs.tigera.io/calico/latest/getting-started/kubernetes/self-managed-onprem/onpremises and a self experienced problem expressed as can be seen below.

Notice: /Stage[main]/Kubernetes::Kube_addons/Exec[Install cni network (preinstall)]/returns: The CustomResourceDefinition "installations.operator.tigera.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes

It came after running the "puppet agent -t" command.