### PR TITLE
Update devcontainer format + Ruby vscode extension

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,38 +1,37 @@
 # devcontainer
 
-
-For format details, see https://aka.ms/devcontainer.json. 
+For format details, see https://aka.ms/devcontainer.json.
 
 For config options, see the README at:
 https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
- 
-``` json
+
+```json
 {
-	"name": "Puppet Development Kit (Community)",
-	"dockerFile": "Dockerfile",
+  "name": "Puppet Development Kit (Community)",
+  "dockerFile": "Dockerfile",
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+          }
+        }
+      },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.profiles.linux": {
-			"bash": {
-				"path": "bash",
-			}
-		}
-	},
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "puppet.puppet-vscode",
+        "shopify.ruby-lsp"
+      ]
+    }
+  }
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"puppet.puppet-vscode",
-		"rebornix.Ruby"
-	],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pdk --version",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "pdk --version",
 }
 ```
-
-
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,19 @@
 {
-	"name": "Puppet Development Kit (Community)",
-	"dockerFile": "Dockerfile",
-
-	"settings": {
-		"terminal.integrated.profiles.linux": {
-			"bash": {
-				"path": "bash"
-			}
-		}
-	},
-
-	"extensions": [
-		"puppet.puppet-vscode",
-		"rebornix.Ruby"
-	]
+  "name": "Puppet Development Kit (Community)",
+  "dockerFile": "Dockerfile",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash"
+          }
+        }
+      },
+      "extensions": [
+        "puppet.puppet-vscode",
+        "shopify.ruby-lsp"
+      ]
+    }
+  }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "shopify.ruby-lsp"
   ]
 }


### PR DESCRIPTION
## Summary

* The devcontainer spec changed to put vscode-specific settings under `customizations.vscode` 
* The rebornix Ruby extension was deprecated, with a recommendation to use the Ruby LSP extension instead
* Replace tabs in JSON with spaces

## Related Issues (if any)

* devcontainers/spec#1
* rubyide/vscode-ruby#dc81c809c82003d26af9c4dc7c89fa8f8a26cbf5

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X ] Manually verified. (For example `puppet apply`)