### PR TITLE
Added zfs support for conatinerd_snapshotter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,10 @@
 #   The default runtime to use with containerd
 #   Defaults to runc
 #
+# [*containerd_snapshotter*]
+#   The default snapshotter to use with containerd
+#   Defaults to overlayfs
+#
 # [*containerd_sandbox_image*]
 #  The configuration for the image pause container
 #  Defaults registry.k8s.io/pause:3.2
@@ -698,6 +702,7 @@ class kubernetes (
   },
   Enum['runc','nvidia'] $containerd_default_runtime_name  = 'runc',
   String $containerd_sandbox_image                        = 'registry.k8s.io/pause:3.2',
+  Enum['overlayfs', 'zfs'] $containerd_snapshotter        = 'overlayfs',
   String $etcd_archive                                    = "etcd-v${etcd_version}-linux-amd64.tar.gz",
   Optional[String] $etcd_archive_checksum                 = undef,
   String $etcd_package_name                               = 'etcd-server',

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -139,6 +139,8 @@ class kubernetes::packages (
   Optional[Hash] $containerd_plugins_registry           = $kubernetes::containerd_plugins_registry,
   Enum['runc','nvidia']
   $containerd_default_runtime_name                      = $kubernetes::containerd_default_runtime_name,
+  Enum['overlayfs', 'zfs']
+  $containerd_snapshotter                               = $kubernetes::containerd_snapshotter,
   String $etcd_archive                                  = $kubernetes::etcd_archive,
   Optional[String] $etcd_archive_checksum               = $kubernetes::etcd_archive_checksum,
   String $etcd_version                                  = $kubernetes::etcd_version,

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -360,6 +360,7 @@ class kubernetes::packages (
               'containerd_sandbox_image' => $containerd_sandbox_image,
               'docker_cgroup_driver' => $docker_cgroup_driver,
               'containerd_default_runtime_name' => $containerd_default_runtime_name,
+              'containerd_snapshotter' => $containerd_snapshotter,
           })
         }
         # Generate using 'containerd config default'

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -112,6 +112,8 @@
 #   no_proxy values. Defaults to false
 # @param containerd_socket
 #   The path to containerd GRPC socket. Defaults to /run/containerd/containerd.sock
+# @param containerd_snapshotter
+#   Configure whcih containerd snapshotter to user. Can be overlayfs or zfs. Defaults to overlayfs
 #
 class kubernetes::packages (
   String $kubernetes_package_version                    = $kubernetes::kubernetes_package_version,

--- a/templates/containerd/config.toml.epp
+++ b/templates/containerd/config.toml.epp
@@ -69,8 +69,8 @@ oom_score = 0
     disable_hugetlb_controller = true
     ignore_image_defined_volumes = false
     [plugins."io.containerd.grpc.v1.cri".containerd]
-      snapshotter = "overlayfs"
       default_runtime_name = "<%= $containerd_default_runtime_name %>"
+      snapshotter = "<%= $containerd_snapshotter -%>"
       no_pivot = false
       disable_snapshot_annotations = true
       discard_unpacked_layers = false


### PR DESCRIPTION
## Summary
Currently only overlayfs is supported, since we are using zfs, would be nice to have this

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)

originally raised https://github.com/puppetlabs/puppetlabs-kubernetes/pull/619