### PR TITLE
Ensure correct scheduler extra arguments passed to v1beta3 template

### DIFF
--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -600,4 +600,20 @@ describe 'kubernetes::config::kubeadm', type: :class do
         .with_content(%r{key: node-role.kubernetes.io/control-plane\n})
     }
   end
+
+  context 'when scheduler_extra_arguments is defined' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.26.0',
+        'scheduler_extra_arguments' => ['bind-address: 0.0.0.0']
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it 'has scheduler extra arguments' do
+      cluster_config = config_yaml.find { |c| c['kind'] == 'ClusterConfiguration' }
+      expect(cluster_config['scheduler']['extraArgs']['bind-address']).to eq('0.0.0.0')
+    end
+  end
 end

--- a/templates/v1beta3/config_kubeadm.yaml.erb
+++ b/templates/v1beta3/config_kubeadm.yaml.erb
@@ -84,9 +84,9 @@ controllerManager:
   <%- end -%>
 <%- end -%>
 scheduler:
-<%- if @scheduler_merged_extra_arguments -%>
+<%- if @scheduler_extra_arguments -%>
   extraArgs:
-  <%- @scheduler_merged_extra_arguments.each do |arg| -%>
+  <%- @scheduler_extra_arguments.each do |arg| -%>
     <%= arg %>
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
## Summary
The v1beta3 template needs to use correct argument to get the scheduler extra args.

## Additional Context
I upgraded from 6.0.0 to 8.0.0 and lost some changes:

```diff
 scheduler:
-  extraArgs:
-    bind-address: 0.0.0.0
```

The Hiera I have is this:

```yaml
kubernetes::scheduler_extra_arguments:
  - 'bind-address: 0.0.0.0'
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)