### PR TITLE
Bump min version of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 8.4.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
## Summary
PR #637 uses stdlib::deferrable_epp that is only available in v8.4.0[1]

[1] puppetlabs/puppetlabs-stdlib#1253

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)