### PR TITLE
Fix missing puppetlabs/apt min requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": "< 10.0.0"
+      "version_requirement": ">= 7.7.0 < 10.0.0"
     },
     {
       "name": "puppet-archive",


### PR DESCRIPTION
`puppetlabs/apt` 7.7.0 is the first release to support Puppet 7

See https://github.com/puppetlabs/puppetlabs-apt/pull/958/commits/bfceb040173244aff36a8bda0cf623e52523c3f3

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)