### PR TITLE
(CAT-2095): Fixed puppetlabs-kubernetes modules CI & nightly failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix: {'platform':['centos-7'],'collection':['puppet7-nightly', 'puppet8-nightly']}
+      matrix: {'platform':['rhel-8'],'collection':['puppet7-nightly', 'puppet8-nightly']}
 
     steps:
     - name: Checkout Source

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix: {'platform':['centos-7'],'collection':['puppet7-nightly', 'puppet8-nightly']}
+      matrix: {'platform':['rhel-8'],'collection':['puppet7-nightly', 'puppet8-nightly']}
 
     steps:
     - name: Checkout Source

--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,8 @@ extra_gemfiles.each do |gemfile|
   end
 end
 # vim: syntax=ruby
+
+
+# Fixed version for puppet-modulebuilder gem, as newer version of this gem does not include tooling folder.
+# We will keep this until we find a solution to either move the tooling folder in to some other folder or get rid of it altogether.
+gem 'puppet-modulebuilder', '1.1.0'

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -11,7 +11,8 @@
 #   When set to true, etcd will be downloaded from the specified source URL.
 #   Defaults to true.
 # @param delegated_pki
-#   Set to true if all required X509 certificates will be provided by external means. Setting this to true will ignore all *_crt and *_key including sa.key and sa.pub files.
+#   Set to true if all required X509 certificates will be provided by external means. 
+#   Setting this to true will ignore all *_crt and *_key including sa.key and sa.pub files.
 #   Defaults to false
 # @param etcd_install_method
 #   The method on how to install etcd. Can be either wget (using etcd_source) or package (using $etcd_package_name)
@@ -96,7 +97,8 @@
 #   "periodic" or "revision"
 #   Defaults to "periodic"
 # @param etcd_compaction_retention
-#   This will tell etcd how much retention to be applied. This value can change depending on `etcd_compaction_method`. An integer or time string (i.e.: "5m") can be used in case of "periodic". Only integer allowed in case of "revision"
+#   This will tell etcd how much retention to be applied. This value can change depending on `etcd_compaction_method`.
+#   An integer or time string (i.e.: "5m") can be used in case of "periodic". Only integer allowed in case of "revision"
 #   Integer or String
 #   Defaults to 0 (disabled)
 # @param api_server_count
@@ -157,8 +159,9 @@
 #   A string array of extra arguments to be passed to scheduler.
 #   Defaults to []
 # @param kubelet_extra_arguments
-#   A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both control planes and nodes.
-#   Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config
+#   A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied
+#   to both control planes and nodes. Use this for critical Kubelet settings such as `pod-infra-container-image` 
+#   which may be problematic to configure via kubelet_extra_config
 #   Defaults to []
 # @param service_cidr
 #   The IP assdress range for service VIPs
@@ -381,9 +384,9 @@ class kubernetes::config::kubeadm (
   }
 
   # to_yaml emits a complete YAML document, so we must remove the leading '---'
-  $kubeadm_extra_config_yaml = regsubst(to_yaml($kubeadm_extra_config), '^---\n', '')
-  $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')
-  $kubelet_extra_config_alpha1_yaml = regsubst(to_yaml($kubelet_extra_config_alpha1), '^---\n', '')
+  $kubeadm_extra_config_yaml = regsubst(stdlib::to_yaml($kubeadm_extra_config), '^---\n', '')
+  $kubelet_extra_config_yaml = regsubst(stdlib::to_yaml($kubelet_extra_config), '^---\n', '')
+  $kubelet_extra_config_alpha1_yaml = regsubst(stdlib::to_yaml($kubelet_extra_config_alpha1), '^---\n', '')
 
   $config_version = $kubernetes_version ? {
     /^1\.1(0|1)/              => 'v1alpha1',

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -48,8 +48,9 @@
 #     [{'key' => 'dedicated','value' => 'NewNode','effect' => 'NoSchedule', 'operator' => 'Equal'}]
 #   Defaults to undef
 # @param kubelet_extra_arguments
-#   A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both control planes and nodes.
-#   Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config
+#   A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied
+#   to both control planes and nodes. Use this for critical Kubelet settings such as `pod-infra-container-image`
+#   which may be problematic to configure via kubelet_extra_config
 #   Defaults to []
 # @param kubelet_extra_config
 #   A hash containing extra configuration data to be serialised with `to_yaml` and appended to Kubelet configuration file for the cluster.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -216,7 +216,8 @@
 #   Defaults to "new"
 #
 # [*etcd_compaction_retention*]
-#     This will tell etcd how much retention to be applied. This value can change depending on `etcd_compaction_method`. An integer or time string (i.e.: "5m") can be used in case of "periodic". Only integer allowed in case of "revision"
+#     This will tell etcd how much retention to be applied. This value can change depending on `etcd_compaction_method`. 
+#     An integer or time string (i.e.: "5m") can be used in case of "periodic". Only integer allowed in case of "revision"
 #   Integer or String
 #   Defaults to 0 (disabled)
 #
@@ -294,7 +295,8 @@
 #   Defaults to []
 #
 # [*delegated_pki*]
-#   Set to true if all required X509 certificates will be provided by external means. Setting this to true will ignore all *_crt and *_key including sa.key and sa.pub files.
+#   Set to true if all required X509 certificates will be provided by external means. 
+#   Setting this to true will ignore all *_crt and *_key including sa.key and sa.pub files.
 #   Defaults to false
 #
 # [*kubernetes_ca_crt*]
@@ -388,8 +390,9 @@
 #  Defaults to {}
 #
 # [*kubelet_extra_arguments*]
-#  A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied to both control planes and nodes.
-#  Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config
+#  A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration applied 
+#  to both control planes and nodes. Use this for critical Kubelet settings such as `pod-infra-container-image` 
+#  which may be problematic to configure via kubelet_extra_config
 #  Defaults to []
 #
 # [*proxy_mode*]

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -64,24 +64,24 @@ class kubernetes::repos (
       'Debian': {
         $codename = fact('os.distro.codename')
         apt::source { 'kubernetes':
-          location => pick($kubernetes_apt_location,'https://apt.kubernetes.io'),
-          repos    => pick($kubernetes_apt_repos,'main'),
-          release  => pick($kubernetes_apt_release,'kubernetes-xenial'),
+          location => pick($kubernetes_apt_location, 'https://apt.kubernetes.io'),
+          repos    => pick($kubernetes_apt_repos, 'main'),
+          release  => pick($kubernetes_apt_release, 'kubernetes-xenial'),
           key      => {
-            'id'     => pick($kubernetes_key_id,'A362B822F6DEDC652817EA46B53DC80D13EDEF05'),
-            'source' => pick($kubernetes_key_source,'https://packages.cloud.google.com/apt/doc/apt-key.gpg'),
+            'id'     => pick($kubernetes_key_id, 'A362B822F6DEDC652817EA46B53DC80D13EDEF05'),
+            'source' => pick($kubernetes_key_source, 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'),
           },
         }
 
         if ($container_runtime == 'docker' and $manage_docker == true) or
         ($container_runtime == 'cri_containerd' and $containerd_install_method == 'package') {
           apt::source { 'docker':
-            location => pick($docker_apt_location,'https://download.docker.com/linux/ubuntu/'),
-            repos    => pick($docker_apt_repos,'stable'),
+            location => pick($docker_apt_location, 'https://download.docker.com/linux/ubuntu/'),
+            repos    => pick($docker_apt_repos, 'stable'),
             release  => pick($docker_apt_release,$codename),
             key      => {
-              'id'     => pick($docker_key_id,'9DC858229FC7DD38854AE2D88D81803C0EBFCD88'),
-              'source' => pick($docker_key_source,'https://download.docker.com/linux/ubuntu/gpg'),
+              'id'     => pick($docker_key_id, '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'),
+              'source' => pick($docker_key_source, 'https://download.docker.com/linux/ubuntu/gpg'),
             },
           }
         }
@@ -91,16 +91,16 @@ class kubernetes::repos (
         ($container_runtime == 'cri_containerd' and $containerd_install_method == 'package') {
           yumrepo { 'docker':
             descr    => 'docker',
-            baseurl  => pick($docker_yum_baseurl,'https://download.docker.com/linux/centos/7/x86_64/stable'),
-            gpgkey   => pick($docker_yum_gpgkey,'https://download.docker.com/linux/centos/gpg'),
+            baseurl  => pick($docker_yum_baseurl, 'https://download.docker.com/linux/centos/7/x86_64/stable'),
+            gpgkey   => pick($docker_yum_gpgkey, 'https://download.docker.com/linux/centos/gpg'),
             gpgcheck => true,
           }
         }
 
         yumrepo { 'kubernetes':
           descr    => 'Kubernetes',
-          baseurl  => pick($kubernetes_yum_baseurl,'https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64'),
-          gpgkey   => pick($kubernetes_yum_gpgkey,'https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg'),
+          baseurl  => pick($kubernetes_yum_baseurl, 'https://pkgs.k8s.io/core:/stable:/v1.28/rpm/'),
+          gpgkey   => pick($kubernetes_yum_gpgkey, 'https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key'),
           gpgcheck => true,
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": "< 10.0.0"
+      "version_requirement": "<= 10.0.0"
     },
     {
       "name": "puppet-archive",

--- a/spec/acceptance/integration_kubernetes_spec.rb
+++ b/spec/acceptance/integration_kubernetes_spec.rb
@@ -55,7 +55,7 @@ describe 'we are able to setup a controller and workers', :integration do
       it 'verify the k8 nodes' do
         run_shell('sleep 20')
         run_shell('KUBECONFIG=/etc/kubernetes/admin.conf kubectl get nodes') do |r|
-          expect(r.stdout).to match(%r{#{hostname1}(\s)+Ready(\s)+control-plane,master})
+          expect(r.stdout).to match(%r{#{hostname1}(\s)+Ready(\s)+control-plane})
           expect(r.stdout).to match(%r{#{hostname2}(\s)+Ready})
           expect(r.stdout).to match(%r{#{hostname3}(\s)+Ready})
         end


### PR DESCRIPTION
## Summary

Fixed puppetlabs-kubernetes modules CI & nightly failures

1. replaced CENTOS-7 with RHEL-8
2. Updated test as per new changes
3. Fixed version for `puppet-modulebuilder` gem, as newer version of this gem does not include `tooling` folder. We will keep this until we find a solution to either move the `tooling` folder in to some other folder or get rid of it altogether.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)