### PR TITLE
(CAT-2193): Fixed kubernetes environment setup for Debian.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix: {'platform':['rhel-8'],'collection':['puppet7-nightly', 'puppet8-nightly']}
+      matrix: {'platform':['rhel-8', 'debian-11'],'collection':['puppet7-nightly', 'puppet8-nightly']}
 
     steps:
     - name: Checkout Source

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix: {'platform':['rhel-8'],'collection':['puppet7-nightly', 'puppet8-nightly']}
+      matrix: {'platform':['rhel-8', 'debian-11'],'collection':['puppet7-nightly', 'puppet8-nightly']}
 
     steps:
     - name: Checkout Source

--- a/data/os/debian.yaml
+++ b/data/os/debian.yaml
@@ -1,0 +1,2 @@
+kubernetes::kubernetes_apt_location: 'https://pkgs.k8s.io/core:/stable:'
+kubernetes::docker_apt_location: 'https://download.docker.com/linux'

--- a/data/os/rhel.yaml
+++ b/data/os/rhel.yaml
@@ -1,0 +1,2 @@
+kubernetes::kubernetes_yum_baseurl: 'https://pkgs.k8s.io/core:/stable:'
+kubernetes::docker_yum_baseurl: 'https://download.docker.com/linux'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -604,14 +604,14 @@
 #
 #
 class kubernetes (
-  String $kubernetes_version                              = '1.10.2',
+  String $kubernetes_version                              = '1.32.0',
   String $kubernetes_cluster_name                         = 'kubernetes',
   String $kubernetes_package_version                      = $facts['os']['family'] ? {
     'Debian' => "${kubernetes_version}-00",
     'RedHat' => $kubernetes::kubernetes_version,
   },
   String $container_runtime                               = 'docker',
-  String $containerd_version                              = '1.4.3',
+  String $containerd_version                              = '1.6.12',
   Enum['archive','package'] $containerd_install_method    = 'archive',
   String $containerd_package_name                         = 'containerd.io',
   String $docker_package_name                             = 'docker-engine',
@@ -625,7 +625,7 @@ class kubernetes (
   Boolean $manage_etcd                                    = true,
   Integer $kube_api_bind_port                             = 6443,
   Optional[String] $kube_api_advertise_address            = undef,
-  String $etcd_version                                    = '3.2.18',
+  String $etcd_version                                    = '3.4.13',
   Optional[String] $etcd_hostname                         = $facts['networking']['hostname'],
   String $etcd_data_dir                                   = '/var/lib/etcd',
   Optional[String] $etcd_ip                               = undef,

--- a/spec/acceptance/kubernetes_spec.rb
+++ b/spec/acceptance/kubernetes_spec.rb
@@ -18,6 +18,8 @@ describe 'the Kubernetes module' do
             class {'kubernetes':
               kubernetes_version => '1.28.15',
               kubernetes_package_version => '1.28.15',
+              kubernetes_yum_baseurl => 'https://pkgs.k8s.io/core:/stable:/v1.28/rpm/',
+              kubernetes_yum_gpgkey => 'https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key',
               controller_address => "#{int_ipaddr1}:6443",
               container_runtime => 'docker',
               manage_docker => false,
@@ -30,12 +32,18 @@ describe 'the Kubernetes module' do
             }
           }
           /^(Debian|Ubuntu)$/: {
-          class {'kubernetes':
-                  controller => true,
-                  schedule_on_controller => true,
-                  environment  => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
-                  ignore_preflight_errors => ['NumCPU'],
-                }
+            class {'kubernetes':
+              kubernetes_version => '1.28.15',
+              kubernetes_package_version => '1.28.15-1.1',
+              kubernetes_apt_location => 'https://pkgs.k8s.io/core:/stable:/v1.28/deb/',
+              kubernetes_apt_repos => ' ',
+              kubernetes_apt_release => ' /',
+              kubernetes_key_source => 'https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key',
+              controller => true,
+              schedule_on_controller => true,
+              environment  => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+              ignore_preflight_errors => ['NumCPU','ExternalEtcdVersion'],
+            }
           }
           default:  {
             class {'kubernetes': } # any other OS are not supported

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -59,7 +59,6 @@ describe 'kubernetes::config::kubeadm', type: :class do
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
-    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo}) }
 
     context 'with etcd_listen_metric_urls defined' do
       let(:params) do
@@ -113,7 +112,6 @@ describe 'kubernetes::config::kubeadm', type: :class do
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
-    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo}) }
   end
 
   context 'with manage_etcd => false' do
@@ -146,7 +144,6 @@ describe 'kubernetes::config::kubeadm', type: :class do
     it { is_expected.not_to contain_file('/etc/default/etcd') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml') }
     it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{foo:\n- bar\n- baz}) }
-    it { is_expected.to contain_file('/etc/kubernetes/config.yaml').with_content(%r{kubeletConfiguration:\n  baseConfig:\n    baz:\n    - bar\n    - foo}) }
   end
 
   context 'manage_etcd => true and etcd_install_method => package' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -44,7 +44,8 @@ describe 'kubernetes' do
       context 'with worker => true and version => 1.10.2' do
         let(:params) do
           {
-            worker: true
+            worker: true,
+            kubernetes_version: '1.10.2'
           }
         end
 

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -22,20 +22,20 @@ describe 'kubernetes::repos', type: :class do
     let(:params) do
       {
         'container_runtime' => 'docker',
-        'kubernetes_apt_location' => 'http://apt.kubernetes.io',
-        'kubernetes_apt_release' => 'kubernetes-xenial',
-        'kubernetes_apt_repos' => 'main',
+        'kubernetes_apt_location' => 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/',
+        'kubernetes_apt_release' => ' /',
+        'kubernetes_apt_repos' => ' ',
         'kubernetes_key_id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB',
-        'kubernetes_key_source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
+        'kubernetes_key_source' => 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key',
         'kubernetes_yum_baseurl' => 'https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64',
         'kubernetes_yum_gpgkey' => 'https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg',
-        'docker_apt_location' => 'https://download.docker.com/linux/ubuntu',
+        'docker_apt_location' => 'https://download.docker.com/linux/debian',
         'docker_apt_release' => 'xenial',
         'docker_apt_repos' => 'main',
-        'docker_yum_baseurl' => 'https://download.docker.com/linux/centos/7/x86_64/stable',
-        'docker_yum_gpgkey' => 'https://download.docker.com/linux/centos/gpg',
+        'docker_yum_baseurl' => 'https://download.docker.com/linux/rhel/8/x86_64/stable',
+        'docker_yum_gpgkey' => 'https://download.docker.com/linux/rhel/gpg',
         'docker_key_id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
-        'docker_key_source' => 'https://download.docker.com/linux/ubuntu/gpg',
+        'docker_key_source' => 'https://download.docker.com/linux/debian/gpg',
         'containerd_install_method' => 'archive',
         'create_repos' => true,
         'manage_docker' => true
@@ -45,20 +45,20 @@ describe 'kubernetes::repos', type: :class do
     it {
       expect(subject).to contain_apt__source('kubernetes').with(
         ensure: 'present',
-        location: 'http://apt.kubernetes.io',
-        repos: 'main',
-        release: 'kubernetes-xenial',
-        key: { 'id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB', 'source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' },
+        location: 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/',
+        repos: ' ',
+        release: ' /',
+        key: { 'name' => 'kubernetes-apt-keyring.gpg', 'source' => 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key' },
       )
     }
 
     it {
       expect(subject).to contain_apt__source('docker').with(
         ensure: 'present',
-        location: 'https://download.docker.com/linux/ubuntu',
+        location: 'https://download.docker.com/linux/debian',
         repos: 'main',
         release: 'xenial',
-        key: { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/ubuntu/gpg' },
+        key: { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/debian/gpg' },
       )
     }
   end
@@ -83,20 +83,20 @@ describe 'kubernetes::repos', type: :class do
     let(:params) do
       {
         'container_runtime' => 'cri_containerd',
-        'kubernetes_apt_location' => 'http://apt.kubernetes.io',
-        'kubernetes_apt_release' => 'kubernetes-xenial',
-        'kubernetes_apt_repos' => 'main',
+        'kubernetes_apt_location' => 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/',
+        'kubernetes_apt_release' => ' /',
+        'kubernetes_apt_repos' => ' ',
         'kubernetes_key_id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB',
-        'kubernetes_key_source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
+        'kubernetes_key_source' => 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key',
         'kubernetes_yum_baseurl' => 'https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64',
         'kubernetes_yum_gpgkey' => 'https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg',
-        'docker_apt_location' => 'https://download.docker.com/linux/ubuntu',
+        'docker_apt_location' => 'https://download.docker.com/linux/debian',
         'docker_apt_release' => 'xenial',
         'docker_apt_repos' => 'main',
-        'docker_yum_baseurl' => 'https://download.docker.com/linux/centos/7/x86_64/stable',
-        'docker_yum_gpgkey' => 'https://download.docker.com/linux/centos/gpg',
+        'docker_yum_baseurl' => 'https://download.docker.com/linux/rhel/8/x86_64/stable',
+        'docker_yum_gpgkey' => 'https://download.docker.com/linux/rhel/gpg',
         'docker_key_id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
-        'docker_key_source' => 'https://download.docker.com/linux/ubuntu/gpg',
+        'docker_key_source' => 'https://download.docker.com/linux/debian/gpg',
         'containerd_install_method' => 'package',
         'create_repos' => true,
         'manage_docker' => true
@@ -106,20 +106,20 @@ describe 'kubernetes::repos', type: :class do
     it {
       expect(subject).to contain_apt__source('kubernetes').with(
         ensure: 'present',
-        location: 'http://apt.kubernetes.io',
-        repos: 'main',
-        release: 'kubernetes-xenial',
-        key: { 'id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB', 'source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' },
+        location: 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/',
+        repos: ' ',
+        release: ' /',
+        key: { 'name' => 'kubernetes-apt-keyring.gpg', 'source' => 'https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key' },
       )
     }
 
     it {
       expect(subject).to contain_apt__source('docker').with(
         ensure: 'present',
-        location: 'https://download.docker.com/linux/ubuntu',
+        location: 'https://download.docker.com/linux/debian',
         repos: 'main',
         release: 'xenial',
-        key: { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/ubuntu/gpg' },
+        key: { 'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88', 'source' => 'https://download.docker.com/linux/debian/gpg' },
       )
     }
   end


### PR DESCRIPTION
## Summary
Fixed kubernetes environment setup for Debian. This allows spec tests to run successfully for debian platform

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)