### PR TITLE
(MAINT): Updated the version for puppetlabs-apt module in metadata.json file

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": "<= 10.0.0"
+      "version_requirement": ">= 10.0.0"
     },
     {
       "name": "puppet-archive",


### PR DESCRIPTION
Updated the version for puppetlabs-apt module in metadata.json file.

## Summary
After a new release of puppetlabs-apt to 10.0.1, broke the dependency check in puppetlabs-kubernetes. This change will fix the dependency issue.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)