### PR TITLE
Fix kubernetes_version matching

### DIFF
--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -95,10 +95,10 @@ class kubernetes::config::worker (
   $kubelet_extra_config_yaml = regsubst(to_yaml($kubelet_extra_config), '^---\n', '')
 
   $template = $kubernetes_version ? {
-    /1\.12/                  => 'v1alpha3',
-    /1\.1(3|4|5\.[012])/     => 'v1beta1',
-    /1\.(16|17|18|19|20|21)/ => 'v1beta2',
-    default                  => 'v1beta3',
+    /^1\.12/                  => 'v1alpha3',
+    /^1\.1(3|4|5\.[012])/     => 'v1beta1',
+    /^1\.(16|17|18|19|20|21)/ => 'v1beta2',
+    default                   => 'v1beta3',
   }
 
   file { '/etc/kubernetes':


### PR DESCRIPTION
# Summary
This PR fixes the Puppet case expression that selects the correct Kubernetes API template version based on `$kubernetes_version`
Previously, the regex patterns were too permissive and matched unintended substrings (e.g., 1.31.12 was incorrectly matching /1\.12/).

The updated implementation ensures that matching occurs strictly on the major.minor portion of the version string, following the format X.Y.Z.

# Changes
Anchored regex patterns with `^` to ensure the version string starts with `1.`

Improved readability by grouping valid minor versions explicitly.

Example of the updated logic:

```puppet
$template = $kubernetes_version ? {
  /^1\.12(\.|$)/                   => 'v1alpha3',
  /^1\.(13|14|15)(\.|$)/           => 'v1beta1',
  /^1\.(16|17|18|19|20|21)(\.|$)/  => 'v1beta2',
  default                          => 'v1beta3',
}
```
# Additional Context
Root cause: Regex patterns were too broad, leading to false positives when the patch version contained substrings like 12.

# Steps to reproduce:

Set `$kubernetes_version = '1.31.12'` → previously matched **v1alpha3**.

After fix → correctly resolves to **v1beta3**.

# Thought process:

Instead of substring matches, I anchor on start-of-string `^` to ensure the regex only evaluates against major.minor.

