### PR TITLE
Support kubeadm v1beta4 on Kuberentes 1.31+

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Defaults to `[]`.
 
 A string array of extra arguments passed to the API server.
 
+**For Kubernetes 1.31+ the format of each array element is `{'name' => '<flag>', 'value' => '<value>'}`**
+
 Defaults to `[]`.
 
 #### `apiserver_extra_volumes`
@@ -410,6 +412,8 @@ Defaults to `undef`.
 
 A string array of extra arguments passed to the controller manager.
 
+**For Kubernetes 1.31+ the format of each array element is `{'name' => '<flag>', 'value' => '<value>'}`**
+
 Defaults to `[]`.
 
 #### `controllermanager_extra_volumes`
@@ -434,6 +438,8 @@ Defaults to `{}`.
 #### `scheduler_extra_arguments`
 
 A string array of extra arguments passed to the scheduler.
+
+**For Kubernetes 1.31+ the format of each array element is `{'name' => '<flag>', 'value' => '<value>'}`**
 
 Defaults to `[]`.
 
@@ -755,6 +761,8 @@ Defaults to `{}`.
 #### `kubelet_extra_arguments`
 
 A string array to be appended to kubeletExtraArgs in the Kubelet's nodeRegistration configuration. It is applied to both control-planes and nodes. Use this for critical Kubelet settings such as `pod-infra-container-image` which may be problematic to configure via kubelet_extra_config and DynamicKubeletConfig.
+
+**For Kubernetes 1.31+ the format of each array element is `{'name' => '<flag>', 'value' => '<value>'}`**
 
 Defaults to `[]`.
 

--- a/manifests/config/kubeadm.pp
+++ b/manifests/config/kubeadm.pp
@@ -393,7 +393,8 @@ class kubernetes::config::kubeadm (
     /^1\.12/                  => 'v1alpha3',
     /^1\.1(3|4|5\.[012])/     => 'v1beta1',
     /^1\.(16|17|18|19|20|21)/ => 'v1beta2',
-    default                  => 'v1beta3',
+    /^1\.(2[2-9]|30)/         => 'v1beta3',
+    default                   => 'v1beta4',
   }
 
   # master role is DEPRECATED

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -98,7 +98,8 @@ class kubernetes::config::worker (
     /^1\.12/                  => 'v1alpha3',
     /^1\.1(3|4|5\.[012])/     => 'v1beta1',
     /^1\.(16|17|18|19|20|21)/ => 'v1beta2',
-    default                   => 'v1beta3',
+    /^1\.(2[2-9]|30)/         => 'v1beta3',
+    default                   => 'v1beta4',
   }
 
   file { '/etc/kubernetes':

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -244,14 +244,14 @@ describe 'kubernetes::config::kubeadm', type: :class do
     it { is_expected.to contain_file('/etc/default/etcd').with_content(%r{ETCD_DATA_DIR="/var/lib/bar"}) }
   end
 
-  context 'with version = 1.12 and node_name => foo and cloud_provider => aws' do
+  context 'with version = 1.32.0 and node_name => foo and cloud_provider => aws' do
     let(:params) do
       {
-        'kubernetes_version' => '1.12.3',
+        'kubernetes_version' => '1.32.0',
         'node_name' => 'foo',
         'cloud_provider' => 'aws',
         'cloud_config' => :undef,
-        'kubelet_extra_arguments' => ['foo: bar']
+        'kubelet_extra_arguments' => [{ 'name' => 'foo', 'value' => 'bar' }]
       }
     end
 
@@ -264,11 +264,15 @@ describe 'kubernetes::config::kubeadm', type: :class do
     end
 
     it 'has cloud-provider==aws in first YAML document (InitConfig) NodeRegistration' do
-      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).to include('cloud-provider' => params['cloud_provider'])
+      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).to include({ 'name' => 'cloud-provider', 'value' => params['cloud_provider'] })
     end
 
     it 'does not have cloud-config in second YAML document (InitConfig) NodeRegistration' do
-      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).not_to include('cloud-config')
+      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).not_to include({ 'name' => 'cloud-provider' })
+    end
+
+    it 'has foo extra arg in first YAML document (InitConfig) NodeRegistration' do
+      expect(config_yaml[0]['nodeRegistration']['kubeletExtraArgs']).to include({ 'name' => 'foo', 'value' => 'bar' })
     end
   end
 

--- a/templates/v1beta4/config_kubeadm.yaml.erb
+++ b/templates/v1beta4/config_kubeadm.yaml.erb
@@ -1,0 +1,173 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: <%= @token %>
+  ttl: <%= @ttl_duration %>
+  usages:
+  - signing
+  - authentication
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: <%= @kube_api_advertise_address %>
+  bindPort: <%= @kube_api_bind_port %>
+nodeRegistration:
+  name: <%= @node_name %>
+  <%- if @container_runtime == "cri_containerd" -%>
+  criSocket: unix:///run/containerd/containerd.sock
+  <%- end -%>
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+  kubeletExtraArgs:
+    <%- if @cloud_provider -%>
+    - name: cloud-provider
+      value: <%= @cloud_provider %>
+    <%- end -%>
+    <%- if @cloud_config -%>
+    - name: cloud-config
+      value: <%= @cloud_config %>
+    <%- end -%>
+    <%- @kubelet_extra_arguments.each do |arg| -%>
+    - name: <%= arg['name'] %>
+      <%- if arg['value'].to_i.to_s == arg['value'] -%>
+      value: "<%= arg['value'] %>"
+      <%- else -%>
+      value: <%= arg['value'] %>
+      <%- end -%>
+    <%- end -%>
+<% if @skip_phases -%>
+skipPhases:
+<% @skip_phases.split(',').each do |skip_phase| -%>
+- <%= skip_phase %>
+<% end -%>
+<% end -%>
+---
+apiServer:
+<%- if @apiserver_cert_extra_sans -%>
+  certSANs:
+  <%- @apiserver_cert_extra_sans.each do |san| -%>
+  - <%= san %>
+  <%- end -%>
+<%- end -%>
+<%- if @apiserver_merged_extra_arguments -%>
+  extraArgs:
+  <%- @apiserver_merged_extra_arguments.each do |arg| -%>
+    - name: <%= arg['name'] %>
+      <%- if arg['value'].to_i.to_s == arg['value'] -%>
+      value: "<%= arg['value'] %>"
+      <%- else -%>
+      value: <%= arg['value'] %>
+      <%- end -%>
+  <%- end -%>
+<%- end -%>
+<%- if @apiserver_merged_extra_volumes -%>
+  extraVolumes:
+  <%- @apiserver_merged_extra_volumes.each do |name, config| -%>
+  - name: <%= name %>
+    hostPath: <%= config['hostPath'] %>
+    mountPath: <%= config['mountPath'] %>
+    readOnly: <%= config['readOnly'] %>
+    pathType: <%= config['pathType'] %>
+  <%- end -%>
+<%- end -%>
+apiVersion: kubeadm.k8s.io/v1beta4
+certificatesDir: /etc/kubernetes/pki
+<%- if @kubernetes_cluster_name != "kubernetes"  -%>
+clusterName: <%= @kubernetes_cluster_name %>
+<%- end -%>
+controlPlaneEndpoint: "<%= @controller_address %>"
+controllerManager:
+<%- if @controllermanager_merged_extra_arguments -%>
+  extraArgs:
+  <%- @controllermanager_merged_extra_arguments.each do |arg| -%>
+    - name: <%= arg['name'] %>
+      <%- if arg['value'].to_i.to_s == arg['value'] -%>
+      value: "<%= arg['value'] %>"
+      <%- else -%>
+      value: <%= arg['value'] %>
+      <%- end -%>
+  <%- end -%>
+<%- end -%>
+<%- if @controllermanager_merged_extra_volumes -%>
+  extraVolumes:
+  <%- @controllermanager_merged_extra_volumes.each do |name, config| -%>
+  - name: <%= name %>
+    hostPath: <%= config['hostPath'] %>
+    mountPath: <%= config['mountPath'] %>
+    readOnly: <%= config['readOnly'] %>
+    pathType: <%= config['pathType'] %>
+  <%- end -%>
+<%- end -%>
+scheduler:
+<%- if @scheduler_extra_arguments -%>
+  extraArgs:
+  <%- @scheduler_extra_arguments.each do |arg| -%>
+    - name: <%= arg['name'] %>
+      <%- if arg['value'].to_i.to_s == arg['value'] -%>
+      value: "<%= arg['value'] %>"
+      <%- else -%>
+      value: <%= arg['value'] %>
+      <%- end -%>
+  <%- end -%>
+<%- end -%>
+etcd:
+    external:
+        caFile: /etc/kubernetes/pki/etcd/ca.crt
+        certFile: /etc/kubernetes/pki/etcd/client.crt
+        endpoints:
+<% @etcd_peers.each do |peer| -%>
+          - https://<%= peer %>:2379
+<% end -%>
+        keyFile: /etc/kubernetes/pki/etcd/client.key
+imageRepository:  <%= @image_repository %>
+<% unless @feature_gates.empty? -%>
+featureGates:
+<% @feature_gates.each_pair do |key,value| -%>
+  <%= key %>: <%= value %>
+<% end -%>
+<% end -%>
+kind: ClusterConfiguration
+kubernetesVersion: v<%= @kubernetes_version %>
+networking:
+  dnsDomain: <%= @dns_domain %>
+  podSubnet: <%= @cni_pod_cidr %>
+  serviceSubnet: <%= @service_cidr %>
+<%- if @kubeadm_extra_config  -%>
+<%= @kubeadm_extra_config_yaml %>
+<%- end -%>
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+bindAddress: 0.0.0.0
+clientConnection:
+  acceptContentTypes: ""
+  burst: 10
+  contentType: application/vnd.kubernetes.protobuf
+  kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+  qps: 5
+clusterCIDR: <%= @cni_pod_cidr %>
+configSyncPeriod: 15m0s
+conntrack:
+  maxPerCore: <%= @conntrack_max_per_core %>
+  min: <%= @conntrack_min %>
+  tcpCloseWaitTimeout: <%= @conntrack_tcp_wait_timeout %>
+  tcpEstablishedTimeout: <%= @conntrack_tcp_stablished_timeout %>
+enableProfiling: false
+healthzBindAddress: 0.0.0.0:10256
+hostnameOverride: ""
+iptables:
+  masqueradeAll: false
+  masqueradeBit: 14
+  minSyncPeriod: 0s
+  syncPeriod: 30s
+ipvs:
+  excludeCIDRs: null
+  minSyncPeriod: 0s
+  scheduler: ""
+  syncPeriod: 30s
+kind: KubeProxyConfiguration
+metricsBindAddress: <%= @metrics_bind_address %>:10249
+mode: "<%= @proxy_mode %>"
+nodePortAddresses: null
+oomScoreAdj: -999
+portRange: ""

--- a/templates/v1beta4/config_worker.yaml.erb
+++ b/templates/v1beta4/config_worker.yaml.erb
@@ -1,0 +1,53 @@
+apiVersion: kubeadm.k8s.io/v1beta4
+caCertPath: /etc/kubernetes/pki/ca.crt
+kind: JoinConfiguration
+<%- if @kubernetes_cluster_name != "kubernetes"  -%>
+clusterName: <%= @kubernetes_cluster_name %>
+<%- end -%>
+discovery:
+  bootstrapToken:
+    token: <%= @discovery_token %>
+    apiServerEndpoint: '<%= @controller_address %>'
+    unsafeSkipCAVerification: false
+    caCertHashes:
+    - 'sha256:<%= @discovery_token_hash %>'
+nodeRegistration:
+  name: <%= @node_name %>
+<%- if @node_extra_taints -%>
+  taints:
+  <%- @node_extra_taints.each do |item| -%>
+  - key: <%= item['key'] %>
+    <%- if item['value'] -%>
+    value: <%= item['value'] %>
+    <%- end -%>
+    <%- if item['operator'] -%>
+    operator: <%= item['operator'] %>
+    <%- end -%>
+    effect: <%= item['effect'] %>
+  <%- end -%>
+<%- end -%>
+  <%- if @container_runtime == "cri_containerd" -%>
+  criSocket: unix:///run/containerd/containerd.sock
+  <%- end -%>
+  kubeletExtraArgs:
+    <%- if @cloud_provider -%>
+    - name: cloud-provider
+      value: <%= @cloud_provider %>
+    <%- end -%>
+    <%- if @cloud_config -%>
+    - name: cloud-config
+      value: <%= @cloud_config %>
+    <%- end -%>
+    <%- @kubelet_extra_arguments.each do |arg| -%>
+    - name: <%= arg['name'] %>
+      value: <%= arg['value'] %>
+    <%- end %>
+<% if @feature_gates -%>
+featureGates: <%= @feature_gates %>
+<% end -%>
+<% if @skip_phases_join -%>
+skipPhases:
+<% @skip_phases_join.each do |skip_phase| -%>
+- <%= skip_phase %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
## Summary
Kubernetes 1.31 introduced kubeadm v1beta4 and deprecated older config versions.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)