### PR TITLE
Fix nvidia runtime for containerd to support systemd driver

### DIFF
--- a/templates/containerd/config.toml.epp
+++ b/templates/containerd/config.toml.epp
@@ -106,6 +106,9 @@ oom_score = 0
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
             BinaryName = "/usr/bin/nvidia-container-runtime"
+<% if $docker_cgroup_driver == 'systemd' { -%>
+            SystemdCgroup = true
+<% } -%>
 <% } -%>
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"


### PR DESCRIPTION
## Summary
Ensure using the nvidia runtime for containerd will also support cgroupv2 via systemd.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)