### PR TITLE
fix: stop overriding the kubeadm control-plane taint on v1beta3

### DIFF
--- a/manifests/kube_addons.pp
+++ b/manifests/kube_addons.pp
@@ -128,9 +128,14 @@ class kubernetes::kube_addons (
   }
 
   if $schedule_on_controller {
-    exec { 'schedule on controller':
-      command => "kubectl taint nodes ${node_name} node-role.kubernetes.io/master-",
-      onlyif  => "kubectl describe nodes ${node_name} | tr -s ' ' | grep 'Taints: node-role.kubernetes.io/master:NoSchedule'",
+    # kubeadm taints control planes with "master" (<=1.23), both keys (1.24),
+    # or "control-plane" (>=1.25). Remove either; each is guarded independently
+    # because kubectl taint errors on a key that is not present.
+    ['control-plane', 'master'].each |String $role| {
+      exec { "schedule on controller ${role}":
+        command => "kubectl taint nodes ${node_name} node-role.kubernetes.io/${role}-",
+        onlyif  => "kubectl describe nodes ${node_name} | tr -s ' ' | grep 'node-role.kubernetes.io/${role}:NoSchedule'",
+      }
     }
   }
 

--- a/spec/classes/config/kubeadm_spec.rb
+++ b/spec/classes/config/kubeadm_spec.rb
@@ -598,6 +598,21 @@ describe 'kubernetes::config::kubeadm', type: :class do
     }
   end
 
+  context 'does not override kubeadm default control-plane taints (v1beta3)' do
+    let(:params) do
+      {
+        'kubernetes_version' => '1.28.0'
+      }
+    end
+
+    let(:config_yaml) { YAML.load_stream(catalogue.resource('file', '/etc/kubernetes/config.yaml').send(:parameters)[:content]) }
+
+    it 'omits nodeRegistration.taints so kubeadm applies its version-correct default' do
+      init = config_yaml.find { |doc| doc['kind'] == 'InitConfiguration' }
+      expect(init['nodeRegistration']).not_to have_key('taints')
+    end
+  end
+
   context 'when scheduler_extra_arguments is defined' do
     let(:params) do
       {

--- a/spec/classes/kube_addons_spec.rb
+++ b/spec/classes/kube_addons_spec.rb
@@ -49,7 +49,13 @@ describe 'kubernetes::kube_addons', type: :class do
       )
     }
 
-    it { is_expected.to contain_exec('schedule on controller') }
+    ['control-plane', 'master'].each do |role|
+      it {
+        is_expected.to contain_exec("schedule on controller #{role}").with_command(
+          "kubectl taint nodes foo node-role.kubernetes.io/#{role}-",
+        )
+      }
+    end
 
     it { is_expected.not_to contain_exec('Install cni network (preinstall)') }
     it { is_expected.not_to contain_file('/etc/kubernetes/calico-installation.yaml') }

--- a/templates/v1beta3/config_kubeadm.yaml.erb
+++ b/templates/v1beta3/config_kubeadm.yaml.erb
@@ -16,9 +16,6 @@ nodeRegistration:
   <%- if @container_runtime == "cri_containerd" -%>
   criSocket: unix:///run/containerd/containerd.sock
   <%- end -%>
-  taints:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
   kubeletExtraArgs:
     <%- if @cloud_provider -%>
     cloud-provider: <%= @cloud_provider %>


### PR DESCRIPTION
stop overriding the kubeadm control-plane taint on v1beta3

## Summary
templates/v1beta3/config_kubeadm.yaml.erb hardcoded node-role.kubernetes.io/master in nodeRegistration.taints. 
kubeadm applies its default taint only when that field is nil (SetNodeRegistrationDynamicDefaults in cmd/kubeadm/app/util/config/initconfiguration.go), so an explicit list suppresses it: master (<=1.23), both keys (1.24), control-plane (>=1.25).

v1beta3 is the config version for every k8s >= 1.22, and cluster_roles.pp runs kubeadm init on every controller rather than joining secondaries, so all control planes were tainted node-role.kubernetes.io/master and none node-role.kubernetes.io/control-plane.
Anything tolerating only the control-plane key, including kubeadm's own CoreDNS since 1.26, is repelled from them.
Dropping the override restores kubeadm's behaviour, matching what the v1alpha3 and v1beta1 templates already do.

Workers are unaffected: their config comes from config_worker.yaml.erb, which emits taints only for node_extra_taints.

schedule_on_controller removed only the master key and so became a no-op after the change; it now removes control-plane and master through independently guarded execs, and the onlyif grep no longer requires the taint to appear first in kubectl describe output.

v1beta2 (k8s 1.16-1.21) and $node_role are left unchanged.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable) => Installing a new master node is enough to reproduce the issue.
- [x] Thought process behind the implementation. => Let upstream kubeadm taint the master nodes with its default taints.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)