### PR TITLE
fix(MODULES-11856): Bump augeasproviders_sysctl to <5.0.0 and core to <6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,11 +22,11 @@
     },
     {
       "name": "puppet-augeasproviders_sysctl",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppet-augeasproviders_core",
-      "version_requirement": ">= 2.1.0 < 5.0.0"
+      "version_requirement": ">= 2.1.0 < 6.0.0"
     },
     {
       "name": "puppet-kmod",


### PR DESCRIPTION
## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)